### PR TITLE
Backwards incompatible changes

### DIFF
--- a/examples/cloudflare-workers-hono/package.json
+++ b/examples/cloudflare-workers-hono/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "dependencies": {
     "@upstash/qstash": "latest",
+    "@upstash/workflow": "link:../../dist",
     "hono": "^4.5.8"
   },
   "devDependencies": {

--- a/examples/cloudflare-workers-hono/src/app.ts
+++ b/examples/cloudflare-workers-hono/src/app.ts
@@ -23,7 +23,7 @@ app.post(
         return output;
       });
 
-      const result2 = await context.run("step2", async () => {
+      await context.run("step2", async () => {
         const output = someWork(result1);
         console.log("step 2 input", result1, "output", output);
       });

--- a/examples/cloudflare-workers/package.json
+++ b/examples/cloudflare-workers/package.json
@@ -17,6 +17,7 @@
 		"wrangler": "^3.60.3"
 	},
 	"dependencies": {
-		"@upstash/qstash": "latest"
+		"@upstash/qstash": "latest",
+		"@upstash/workflow": "link:../../dist"
 	}
 }

--- a/examples/cloudflare-workers/src/index.ts
+++ b/examples/cloudflare-workers/src/index.ts
@@ -15,7 +15,7 @@ export default serve<{ text: string }>(
 			return output;
 		});
 
-		const result2 = await context.run('step2', async () => {
+		await context.run('step2', async () => {
 			const output = someWork(result1);
 			console.log('step 2 input', result1, 'output', output);
 		});

--- a/examples/cloudflare-workers/src/index.ts
+++ b/examples/cloudflare-workers/src/index.ts
@@ -4,25 +4,23 @@ const someWork = (input: string) => {
 	return `processed '${JSON.stringify(input)}'`;
 };
 
-export default {
-	fetch: serve<{ text: string }>(
-		async (context) => {
-			if (!context.requestPayload) throw new Error('No payload given, send a curl request to start the workflow');
+export default serve<{ text: string }>(
+	async (context) => {
+		if (!context.requestPayload) throw new Error('No payload given, send a curl request to start the workflow');
 
-			const input = context.requestPayload.text;
-			const result1 = await context.run('step1', async () => {
-				const output = someWork(input);
-				console.log('step 1 input', input, 'output', output);
-				return output;
-			});
+		const input = context.requestPayload.text;
+		const result1 = await context.run('step1', async () => {
+			const output = someWork(input);
+			console.log('step 1 input', input, 'output', output);
+			return output;
+		});
 
-			const result2 = await context.run('step2', async () => {
-				const output = someWork(result1);
-				console.log('step 2 input', result1, 'output', output);
-			});
-		},
-		{
-			receiver: undefined,
-		},
-	),
-};
+		const result2 = await context.run('step2', async () => {
+			const output = someWork(result1);
+			console.log('step 2 input', result1, 'output', output);
+		});
+	},
+	{
+		receiver: undefined,
+	},
+)

--- a/examples/hono/.env.example
+++ b/examples/hono/.env.example
@@ -1,0 +1,1 @@
+QSTASH_TOKEN=""

--- a/examples/hono/package.json
+++ b/examples/hono/package.json
@@ -5,6 +5,7 @@
   },
   "dependencies": {
     "@upstash/qstash": "latest",
+    "@upstash/workflow": "^0.1.0",
     "hono": "^4.5.8"
   },
   "devDependencies": {

--- a/examples/hono/src/index.ts
+++ b/examples/hono/src/index.ts
@@ -23,7 +23,7 @@ app.post(
         return output;
       });
 
-      const result2 = await context.run("step2", async () => {
+      await context.run("step2", async () => {
         const output = someWork(result1);
         console.log("step 2 input", result1, "output", output);
       });

--- a/examples/image-gen-with-workflow/app/api/workflow-simple/route.ts
+++ b/examples/image-gen-with-workflow/app/api/workflow-simple/route.ts
@@ -4,7 +4,7 @@ import { ImageResponse } from 'utils/types'
 
 const redis = Redis.fromEnv()
 
-export const POST = serve<{ prompt: string }>(async (context) => {
+export const { POST } = serve<{ prompt: string }>(async (context) => {
   // get prompt from request
   const { prompt } = context.requestPayload
 

--- a/examples/image-gen-with-workflow/app/api/workflow/route.ts
+++ b/examples/image-gen-with-workflow/app/api/workflow/route.ts
@@ -62,7 +62,7 @@ export const POST = async (request: NextRequest) => {
  *
  * See docs to learn more https://upstash.com/docs/qstash/workflow/basics/serve
  */
-const serveMethod = serve<CallPayload>(async (context) => {
+const { POST: serveMethod } = serve<CallPayload>(async (context) => {
   // get prompt from payload
   const payload = context.requestPayload
   const prompt = PROMPTS[payload.promptIndex]

--- a/examples/image-gen-with-workflow/package.json
+++ b/examples/image-gen-with-workflow/package.json
@@ -14,6 +14,7 @@
     "@upstash/qstash": "^2.7.8",
     "@upstash/ratelimit": "^2.0.3",
     "@upstash/redis": "^1.34.0",
+    "@upstash/workflow": "link:../../dist",
     "@vercel/functions": "^1.4.1",
     "clsx": "^2.1.1",
     "next": "14.2.13",

--- a/examples/nextjs-pages/package.json
+++ b/examples/nextjs-pages/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@upstash/qstash": "latest",
+    "@upstash/workflow": "link:../../dist",
     "clsx": "^2.1.1",
     "next": "14.2.8",
     "react": "^18",

--- a/examples/nextjs-pages/src/pages/api/path.ts
+++ b/examples/nextjs-pages/src/pages/api/path.ts
@@ -1,11 +1,11 @@
+import { servePagesRouter } from "@upstash/workflow/nextjs";
 
 const someWork = (input: string) => {
   return `processed '${JSON.stringify(input)}'`
 }
 
-import { servePagesRouter } from "@upstash/qstash/nextjs";
 
-export default servePagesRouter<string>(
+const { handler } = servePagesRouter<string>(
   async (context) => {
     const input = context.requestPayload
     const result1 = await context.run("step1", async () => {
@@ -23,3 +23,5 @@ export default servePagesRouter<string>(
     receiver: undefined
   }
 )
+
+export default handler

--- a/examples/nextjs/app/auth/route.ts
+++ b/examples/nextjs/app/auth/route.ts
@@ -5,13 +5,12 @@ export const POST = serve<string>(async (context) => {
     console.error('Authentication failed.')
     return
   }
-  const input = context.requestPayload
 
-  const result1 = await context.run('step1', async () => {
+  await context.run('step1', async () => {
     return 'output 1'
   })
 
-  const result2 = await context.run('step2', async () => {
+  await context.run('step2', async () => {
     return 'output 2'
   })
 })

--- a/examples/nextjs/app/northStar/route.ts
+++ b/examples/nextjs/app/northStar/route.ts
@@ -1,9 +1,5 @@
 import { serve } from '@upstash/workflow/nextjs'
 
-const someWork = (input: string) => {
-  return `processed '${input}'`
-}
-
 type Invoice = {
   date: number
   email: string

--- a/examples/nextjs/app/northStar/route.ts
+++ b/examples/nextjs/app/northStar/route.ts
@@ -27,7 +27,7 @@ const attemptCharge = (invoice: Invoice) => {
   return false
 }
 
-export const POST = serve<Invoice>(async (context) => {
+export const { POST } = serve<Invoice>(async (context) => {
   const x = Math.random()
   const invoice = context.requestPayload
 

--- a/examples/nextjs/app/northStarSimple/route.ts
+++ b/examples/nextjs/app/northStarSimple/route.ts
@@ -27,7 +27,7 @@ const attemptCharge = (invoice: Invoice) => {
   return false
 }
 
-export const POST = serve<Invoice>(async (context) => {
+export const { POST } = serve<Invoice>(async (context) => {
   const invoice = context.requestPayload
 
   for (let index = 0; index < 3; index++) {

--- a/examples/nextjs/app/northStarSimple/route.ts
+++ b/examples/nextjs/app/northStarSimple/route.ts
@@ -1,9 +1,5 @@
 import { serve } from '@upstash/workflow/nextjs'
 
-const someWork = (input: string) => {
-  return `processed '${input}'`
-}
-
 type Invoice = {
   date: number
   email: string

--- a/examples/nextjs/app/path/route.ts
+++ b/examples/nextjs/app/path/route.ts
@@ -4,7 +4,7 @@ const someWork = (input: string) => {
   return `processed '${JSON.stringify(input)}'`
 }
 
-export const POST = serve<string>(async (context) => {
+export const { POST } = serve<string>(async (context) => {
   const input = context.requestPayload
   const result1 = await context.run('step1', async () => {
     const output = someWork(input)

--- a/examples/nextjs/app/path/route.ts
+++ b/examples/nextjs/app/path/route.ts
@@ -12,7 +12,7 @@ export const { POST } = serve<string>(async (context) => {
     return output
   })
 
-  const result2 = await context.run('step2', async () => {
+  await context.run('step2', async () => {
     const output = someWork(result1)
     console.log('step 2 input', result1, 'output', output)
   })

--- a/examples/nextjs/app/sleep/route.ts
+++ b/examples/nextjs/app/sleep/route.ts
@@ -22,7 +22,7 @@ export const { POST } = serve<string>(async (context) => {
 
   await context.sleep('sleep2', 2)
 
-  const result3 = await context.run('step3', async () => {
+  await context.run('step3', async () => {
     const output = someWork(result2)
     console.log('step 3 input', result2, 'output', output)
   })

--- a/examples/nextjs/app/sleep/route.ts
+++ b/examples/nextjs/app/sleep/route.ts
@@ -4,7 +4,7 @@ const someWork = (input: string) => {
   return `processed '${JSON.stringify(input)}'`
 }
 
-export const POST = serve<string>(async (context) => {
+export const { POST } = serve<string>(async (context) => {
   const input = context.requestPayload
   const result1 = await context.run('step1', async () => {
     const output = someWork(input)

--- a/examples/nextjs/app/sleepWithoutAwait/route.ts
+++ b/examples/nextjs/app/sleepWithoutAwait/route.ts
@@ -1,9 +1,5 @@
 import { serve } from '@upstash/workflow/nextjs'
 
-const someWork = (input: string) => {
-  return `processed '${input}'`
-}
-
 type Invoice = {
   date: number
   email: string

--- a/examples/nextjs/app/sleepWithoutAwait/route.ts
+++ b/examples/nextjs/app/sleepWithoutAwait/route.ts
@@ -27,7 +27,7 @@ const attemptCharge = (invoice: Invoice) => {
   return false
 }
 
-export const POST = serve<Invoice>(async (context) => {
+export const { POST } = serve<Invoice>(async (context) => {
   const x = Math.random()
   const invoice = context.requestPayload
 

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@upstash/qstash": "^2.7.12",
-    "@upstash/workflow": "file:../../dist",
+    "@upstash/workflow": "link:../../dist",
     "clsx": "^2.1.1",
     "next": "14.2.4",
     "react": "^18.3.1",

--- a/examples/nuxt/package.json
+++ b/examples/nuxt/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@upstash/qstash": "latest",
+    "@upstash/workflow": "link:../../dist",
     "nuxt": "^3.12.4",
     "vue": "latest"
   },

--- a/examples/nuxt/server/api/northStar.ts
+++ b/examples/nuxt/server/api/northStar.ts
@@ -28,7 +28,7 @@ const attemptCharge = (invoice: Invoice) => {
   return false;
 }
 
-export default serve<Invoice>(
+const { handler } = serve<Invoice>(
   async context => {
     const x = Math.random()
     const invoice = context.requestPayload
@@ -66,4 +66,4 @@ export default serve<Invoice>(
   }
 )
 
-
+export default handler

--- a/examples/nuxt/server/api/northStar.ts
+++ b/examples/nuxt/server/api/northStar.ts
@@ -1,10 +1,6 @@
 
 import { serve } from "@upstash/workflow/h3";
 
-const someWork = (input: string) => {
-  return `processed '${input}'`
-}
-
 type Invoice = {
   date: number,
   email: string,

--- a/examples/nuxt/server/api/northStarSimple.ts
+++ b/examples/nuxt/server/api/northStarSimple.ts
@@ -27,7 +27,7 @@ const attemptCharge = (invoice: Invoice) => {
   return false;
 };
 
-export default serve<Invoice>(async (context) => {
+const { handler } = serve<Invoice>(async (context) => {
   const invoice = context.requestPayload;
 
   for (let index = 0; index < 3; index++) {
@@ -59,3 +59,5 @@ export default serve<Invoice>(async (context) => {
     return true;
   });
 });
+
+export default handler

--- a/examples/nuxt/server/api/northStarSimple.ts
+++ b/examples/nuxt/server/api/northStarSimple.ts
@@ -1,9 +1,5 @@
 import { serve } from "@upstash/workflow/h3";
 
-const someWork = (input: string) => {
-  return `processed '${input}'`;
-};
-
 type Invoice = {
   date: number;
   email: string;

--- a/examples/nuxt/server/api/path.ts
+++ b/examples/nuxt/server/api/path.ts
@@ -12,7 +12,7 @@ const { handler } = serve<string>(async (context) => {
     return output;
   });
 
-  const result2 = await context.run("step2", async () => {
+  await context.run("step2", async () => {
     const output = someWork(result1);
     console.log("step 2 input", result1, "output", output);
   });

--- a/examples/nuxt/server/api/path.ts
+++ b/examples/nuxt/server/api/path.ts
@@ -4,7 +4,7 @@ const someWork = (input: string) => {
   return `processed '${JSON.stringify(input)}'`;
 };
 
-export default serve<string>(async (context) => {
+const { handler } = serve<string>(async (context) => {
   const input = context.requestPayload;
   const result1 = await context.run("step1", async () => {
     const output = someWork(input);
@@ -17,3 +17,5 @@ export default serve<string>(async (context) => {
     console.log("step 2 input", result1, "output", output);
   });
 });
+
+export default handler

--- a/examples/nuxt/server/api/sleep.ts
+++ b/examples/nuxt/server/api/sleep.ts
@@ -24,7 +24,7 @@ const { handler } = serve<string>(
 
     await context.sleep("sleep2", 2)
 
-    const result3 = await context.run("step3", async () => {
+    await context.run("step3", async () => {
       const output = someWork(result2)
       console.log("step 3 input", result2, "output", output)
     });

--- a/examples/nuxt/server/api/sleep.ts
+++ b/examples/nuxt/server/api/sleep.ts
@@ -5,7 +5,7 @@ const someWork = (input: string) => {
   return `processed '${JSON.stringify(input)}'`
 }
 
-export default serve<string>(
+const { handler } = serve<string>(
   async context => {
     const input = context.requestPayload
     const result1 = await context.run("step1", async () => {
@@ -31,4 +31,4 @@ export default serve<string>(
   }
 )
 
-
+export default handler

--- a/examples/nuxt/server/api/sleepWithoutAwait.ts
+++ b/examples/nuxt/server/api/sleepWithoutAwait.ts
@@ -1,9 +1,5 @@
 import { serve } from "@upstash/workflow/h3";
 
-const someWork = (input: string) => {
-  return `processed '${input}'`;
-};
-
 type Invoice = {
   date: number;
   email: string;

--- a/examples/nuxt/server/api/sleepWithoutAwait.ts
+++ b/examples/nuxt/server/api/sleepWithoutAwait.ts
@@ -27,7 +27,7 @@ const attemptCharge = (invoice: Invoice) => {
   return false;
 };
 
-export default serve<Invoice>(async (context) => {
+const { handler } = serve<Invoice>(async (context) => {
   const x = Math.random();
   const invoice = context.requestPayload;
 
@@ -64,3 +64,5 @@ export default serve<Invoice>(async (context) => {
     return true;
   });
 });
+
+export default handler

--- a/examples/solidjs/package.json
+++ b/examples/solidjs/package.json
@@ -18,6 +18,7 @@
     "@solidjs/router": "^0.13.6",
     "@solidjs/start": "^1.0.2",
     "@upstash/qstash": "latest",
+    "@upstash/workflow": "link:../../dist",
     "clsx": "^2.1.1",
     "solid-js": "^1.8.17",
     "tailwind-merge": "^2.5.2"

--- a/examples/solidjs/src/routes/northStar.ts
+++ b/examples/solidjs/src/routes/northStar.ts
@@ -27,7 +27,7 @@ const attemptCharge = (invoice: Invoice) => {
   return false;
 }
 
-export const POST = serve<Invoice>(
+export const { POST } = serve<Invoice>(
   async context => {
     const x = Math.random()
     const invoice = context.requestPayload

--- a/examples/solidjs/src/routes/northStar.ts
+++ b/examples/solidjs/src/routes/northStar.ts
@@ -1,9 +1,5 @@
 import { serve } from "@upstash/workflow/solidjs"
 
-const someWork = (input: string) => {
-  return `processed '${input}'`
-}
-
 type Invoice = {
   date: number,
   email: string,

--- a/examples/solidjs/src/routes/northStarSimple.ts
+++ b/examples/solidjs/src/routes/northStarSimple.ts
@@ -1,9 +1,5 @@
 import { serve } from "@upstash/workflow/solidjs"
 
-const someWork = (input: string) => {
-  return `processed '${input}'`
-}
-
 type Invoice = {
   date: number,
   email: string,

--- a/examples/solidjs/src/routes/northStarSimple.ts
+++ b/examples/solidjs/src/routes/northStarSimple.ts
@@ -27,7 +27,7 @@ const attemptCharge = (invoice: Invoice) => {
   return false;
 }
 
-export const POST = serve<Invoice>(
+export const { POST } = serve<Invoice>(
   async context => {
     const invoice = context.requestPayload
     

--- a/examples/solidjs/src/routes/path.ts
+++ b/examples/solidjs/src/routes/path.ts
@@ -4,7 +4,7 @@ const someWork = (input: string) => {
   return `processed '${JSON.stringify(input)}'`
 }
 
-export const POST = serve<string>(
+export const { POST } = serve<string>(
   async context => {
     const input = context.requestPayload
     const result1 = await context.run("step1", async () => {

--- a/examples/solidjs/src/routes/path.ts
+++ b/examples/solidjs/src/routes/path.ts
@@ -13,7 +13,7 @@ export const { POST } = serve<string>(
       return output
     });
 
-    const result2 = await context.run("step2", async () => {
+    await context.run("step2", async () => {
       const output = someWork(result1)
       console.log("step 2 input", result1, "output", output)
     });

--- a/examples/solidjs/src/routes/sleep.ts
+++ b/examples/solidjs/src/routes/sleep.ts
@@ -4,7 +4,7 @@ const someWork = (input: string) => {
   return `processed '${JSON.stringify(input)}'`
 }
 
-export const POST = serve<string>(
+export const { POST } = serve<string>(
   async context => {
     const input = context.requestPayload
     const result1 = await context.run("step1", async () => {

--- a/examples/solidjs/src/routes/sleep.ts
+++ b/examples/solidjs/src/routes/sleep.ts
@@ -23,7 +23,7 @@ export const { POST } = serve<string>(
 
     await context.sleep("sleep2", 2)
 
-    const result3 = await context.run("step3", async () => {
+    await context.run("step3", async () => {
       const output = someWork(result2)
       console.log("step 3 input", result2, "output", output)
     });

--- a/examples/solidjs/src/routes/sleepWithoutAwait.ts
+++ b/examples/solidjs/src/routes/sleepWithoutAwait.ts
@@ -27,7 +27,7 @@ const attemptCharge = (invoice: Invoice) => {
   return false;
 }
 
-export const POST = serve<Invoice>(
+export const { POST } = serve<Invoice>(
   async context => {
     const x = Math.random()
     const invoice = context.requestPayload

--- a/examples/solidjs/src/routes/sleepWithoutAwait.ts
+++ b/examples/solidjs/src/routes/sleepWithoutAwait.ts
@@ -1,9 +1,5 @@
 import { serve } from "@upstash/workflow/solidjs"
 
-const someWork = (input: string) => {
-  return `processed '${input}'`
-}
-
 type Invoice = {
   date: number,
   email: string,

--- a/examples/sveltekit/package.json
+++ b/examples/sveltekit/package.json
@@ -24,6 +24,7 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@upstash/qstash": "latest"
+		"@upstash/qstash": "latest",
+		"@upstash/workflow": "link:../../dist"
 	}
 }

--- a/examples/sveltekit/src/routes/northStar/+server.ts
+++ b/examples/sveltekit/src/routes/northStar/+server.ts
@@ -30,7 +30,7 @@ const attemptCharge = (invoice: Invoice) => {
   return false;
 }
 
-export const POST = serve<Invoice>(
+export const { POST } = serve<Invoice>(
   async context => {
     const x = Math.random()
     const invoice = context.requestPayload

--- a/examples/sveltekit/src/routes/northStar/+server.ts
+++ b/examples/sveltekit/src/routes/northStar/+server.ts
@@ -1,11 +1,6 @@
 
 import { serve } from "@upstash/workflow/svelte";
 import { env } from '$env/dynamic/private'
-import { Client, Receiver } from "@upstash/qstash";
-
-const someWork = (input: string) => {
-  return `processed '${input}'`
-}
 
 type Invoice = {
   date: number,

--- a/examples/sveltekit/src/routes/northStarSimple/+server.ts
+++ b/examples/sveltekit/src/routes/northStarSimple/+server.ts
@@ -29,7 +29,7 @@ const attemptCharge = (invoice: Invoice) => {
   return false;
 }
 
-export const POST = serve<Invoice>(
+export const { POST } = serve<Invoice>(
   async context => {
     const invoice = context.requestPayload
     

--- a/examples/sveltekit/src/routes/northStarSimple/+server.ts
+++ b/examples/sveltekit/src/routes/northStarSimple/+server.ts
@@ -1,10 +1,5 @@
 import { serve } from "@upstash/workflow/svelte";
 import { env } from '$env/dynamic/private'
-import { Client, Receiver } from "@upstash/qstash";
-
-const someWork = (input: string) => {
-  return `processed '${input}'`
-}
 
 type Invoice = {
   date: number,

--- a/examples/sveltekit/src/routes/path/+server.ts
+++ b/examples/sveltekit/src/routes/path/+server.ts
@@ -5,7 +5,7 @@ const someWork = (input: string) => {
   return `processed '${JSON.stringify(input)}'`
 }
 
-export const POST = serve<string>(
+export const { POST } = serve<string>(
   async context => {
     const input = context.requestPayload
     const result1 = await context.run("step1", async () => {

--- a/examples/sveltekit/src/routes/path/+server.ts
+++ b/examples/sveltekit/src/routes/path/+server.ts
@@ -14,7 +14,7 @@ export const { POST } = serve<string>(
       return output
     });
 
-    const result2 = await context.run("step2", async () => {
+    await context.run("step2", async () => {
       const output = someWork(result1)
       console.log("step 2 input", result1, "output", output)
     });

--- a/examples/sveltekit/src/routes/sleep/+server.ts
+++ b/examples/sveltekit/src/routes/sleep/+server.ts
@@ -1,6 +1,5 @@
 import { serve } from "@upstash/workflow/svelte";
 import { env } from '$env/dynamic/private'
-import { Client, Receiver } from "@upstash/qstash";
 
 const someWork = (input: string) => {
   return `processed '${JSON.stringify(input)}'`
@@ -25,7 +24,7 @@ export const { POST } = serve<string>(
 
     await context.sleep("sleep2", 2)
 
-    const result3 = await context.run("step3", async () => {
+    await context.run("step3", async () => {
       const output = someWork(result2)
       console.log("step 3 input", result2, "output", output)
     });

--- a/examples/sveltekit/src/routes/sleep/+server.ts
+++ b/examples/sveltekit/src/routes/sleep/+server.ts
@@ -6,7 +6,7 @@ const someWork = (input: string) => {
   return `processed '${JSON.stringify(input)}'`
 }
 
-export const POST = serve<string>(
+export const { POST } = serve<string>(
   async context => {
     const input = context.requestPayload
     const result1 = await context.run("step1", async () => {

--- a/examples/sveltekit/src/routes/sleepWithoutAwait/+server.ts
+++ b/examples/sveltekit/src/routes/sleepWithoutAwait/+server.ts
@@ -1,10 +1,5 @@
 import { serve } from "@upstash/workflow/svelte";
 import { env } from '$env/dynamic/private'
-import { Client, Receiver } from "@upstash/qstash";
-
-const someWork = (input: string) => {
-  return `processed '${input}'`
-}
 
 type Invoice = {
   date: number,

--- a/examples/sveltekit/src/routes/sleepWithoutAwait/+server.ts
+++ b/examples/sveltekit/src/routes/sleepWithoutAwait/+server.ts
@@ -29,7 +29,7 @@ const attemptCharge = (invoice: Invoice) => {
   return false;
 }
 
-export const POST = serve<Invoice>(
+export const { POST } = serve<Invoice>(
   async context => {
     const x = Math.random()
     const invoice = context.requestPayload

--- a/package.json
+++ b/package.json
@@ -92,5 +92,8 @@
   },
   "dependencies": {
     "@upstash/qstash": "^2.7.12"
+  },
+  "directories": {
+    "example": "examples"
   }
 }

--- a/platforms/cloudflare.ts
+++ b/platforms/cloudflare.ts
@@ -59,14 +59,14 @@ const getArgs = (
 export const serve = <TInitialPayload = unknown>(
   routeFunction: RouteFunction<TInitialPayload>,
   options?: Omit<WorkflowServeOptions<Response, TInitialPayload>, "onStepFinish">
-): ((...args: PagesHandlerArgs | WorkersHandlerArgs) => Promise<Response>) => {
-  const handler = async (...args: PagesHandlerArgs | WorkersHandlerArgs) => {
+): { fetch: ((...args: PagesHandlerArgs | WorkersHandlerArgs) => Promise<Response>) } => {
+  const fetch = async (...args: PagesHandlerArgs | WorkersHandlerArgs) => {
     const { request, env } = getArgs(args);
-    const serveHandler = serveBase(routeFunction, {
+    const { handler: serveHandler } = serveBase(routeFunction, {
       env,
       ...options,
     });
     return await serveHandler(request);
   };
-  return handler;
+  return { fetch };
 };

--- a/platforms/cloudflare.ts
+++ b/platforms/cloudflare.ts
@@ -59,7 +59,7 @@ const getArgs = (
 export const serve = <TInitialPayload = unknown>(
   routeFunction: RouteFunction<TInitialPayload>,
   options?: Omit<WorkflowServeOptions<Response, TInitialPayload>, "onStepFinish">
-): { fetch: ((...args: PagesHandlerArgs | WorkersHandlerArgs) => Promise<Response>) } => {
+): { fetch: (...args: PagesHandlerArgs | WorkersHandlerArgs) => Promise<Response> } => {
   const fetch = async (...args: PagesHandlerArgs | WorkersHandlerArgs) => {
     const { request, env } = getArgs(args);
     const { handler: serveHandler } = serveBase(routeFunction, {

--- a/platforms/h3.ts
+++ b/platforms/h3.ts
@@ -37,8 +37,9 @@ export const serve = <TInitialPayload = unknown>(
       method: "POST",
     });
 
-    const serveHandler = serveBase<TInitialPayload>(routeFunction, options);
+    const { handler: serveHandler } = serveBase<TInitialPayload>(routeFunction, options);
     return await serveHandler(request);
   });
-  return handler;
+
+  return { handler };
 };

--- a/platforms/hono.ts
+++ b/platforms/hono.ts
@@ -31,7 +31,7 @@ export const serve = <
     const environment = context.env;
     const request = context.req.raw;
 
-    const serveHandler = serveBase(routeFunction, {
+    const { handler: serveHandler } = serveBase(routeFunction, {
       // when hono is used without cf workers, it sends a DebugHTTPServer
       // object in `context.env`. don't pass env if this is the case:
       env: "QSTASH_TOKEN" in environment ? environment : undefined,

--- a/platforms/nextjs.ts
+++ b/platforms/nextjs.ts
@@ -27,7 +27,7 @@ export const serve = <TInitialPayload = unknown>(
   return {
     POST: async (request: Request) => {
       return await serveHandler(request);
-    }
+    },
   };
 };
 
@@ -59,5 +59,5 @@ export const servePagesRouter = <TInitialPayload = unknown>(
     res.status(response.status).json(await response.json());
   };
 
-  return { handler }
+  return { handler };
 };

--- a/platforms/solidjs.ts
+++ b/platforms/solidjs.ts
@@ -28,9 +28,9 @@ export const serve = <TInitialPayload = unknown>(
     }
 
     // create serve handler
-    const serveHandler = serveBase<TInitialPayload>(routeFunction, options);
+    const { handler: serveHandler } = serveBase<TInitialPayload>(routeFunction, options);
 
     return await serveHandler(event.request);
   };
-  return handler;
+  return { POST: handler };
 };

--- a/platforms/svelte.ts
+++ b/platforms/svelte.ts
@@ -17,11 +17,11 @@ export const serve = <TInitialPayload = unknown>(
   options: Omit<WorkflowServeOptions<Response, TInitialPayload>, "onStepFinish"> & {
     env: WorkflowServeOptions["env"];
   }
-): RequestHandler => {
+): { POST: RequestHandler } => {
   const handler: RequestHandler = async ({ request }) => {
-    const serveMethod = serveBase<TInitialPayload>(routeFunction, options);
-    return await serveMethod(request);
+    const { handler: serveHandler } = serveBase<TInitialPayload>(routeFunction, options);
+    return await serveHandler(request);
   };
 
-  return handler;
+  return { POST: handler };
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,7 @@ export const WORKFLOW_ID_HEADER = "Upstash-Workflow-RunId";
 export const WORKFLOW_INIT_HEADER = "Upstash-Workflow-Init";
 export const WORKFLOW_URL_HEADER = "Upstash-Workflow-Url";
 export const WORKFLOW_FAILURE_HEADER = "Upstash-Workflow-Is-Failure";
+export const WORKFLOW_FEATURE_HEADER = "Upstash-Feature-Set";
 
 export const WORKFLOW_PROTOCOL_VERSION = "1";
 export const WORKFLOW_PROTOCOL_VERSION_HEADER = "Upstash-Workflow-Sdk-Version";

--- a/src/context/auto-executor.test.ts
+++ b/src/context/auto-executor.test.ts
@@ -120,6 +120,7 @@ describe("auto-executor", () => {
             {
               destination: WORKFLOW_ENDPOINT,
               headers: {
+                "upstash-feature-set": "WF_NoDelete",
                 "content-type": "application/json",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",
@@ -207,6 +208,7 @@ describe("auto-executor", () => {
               body: '{"stepId":0,"stepName":"sleep for some time","stepType":"SleepFor","sleepFor":123,"concurrent":2,"targetStep":1}',
               destination: WORKFLOW_ENDPOINT,
               headers: {
+                "upstash-feature-set": "WF_NoDelete",
                 "content-type": "application/json",
                 "upstash-delay": "123s",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
@@ -221,6 +223,7 @@ describe("auto-executor", () => {
               body: '{"stepId":0,"stepName":"sleep until next day","stepType":"SleepUntil","sleepUntil":123123,"concurrent":2,"targetStep":2}',
               destination: WORKFLOW_ENDPOINT,
               headers: {
+                "upstash-feature-set": "WF_NoDelete",
                 "content-type": "application/json",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",
@@ -273,6 +276,7 @@ describe("auto-executor", () => {
             {
               destination: WORKFLOW_ENDPOINT,
               headers: {
+                "upstash-feature-set": "WF_NoDelete",
                 "content-type": "application/json",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",
@@ -325,6 +329,7 @@ describe("auto-executor", () => {
             {
               destination: WORKFLOW_ENDPOINT,
               headers: {
+                "upstash-feature-set": "WF_NoDelete",
                 "content-type": "application/json",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",

--- a/src/context/context.test.ts
+++ b/src/context/context.test.ts
@@ -95,7 +95,7 @@ describe("context tests", () => {
 
     const throws = async () => {
       await context.run("outer step", async () => {
-        await context.call("inner call", { url: "https://some-url.com"});
+        await context.call("inner call", { url: "https://some-url.com" });
       });
     };
     expect(throws).toThrow(
@@ -137,6 +137,7 @@ describe("context tests", () => {
             body: '{"stepId":1,"stepName":"my-step","stepType":"Run","out":"my-result","concurrent":1}',
             destination: WORKFLOW_ENDPOINT,
             headers: {
+              "upstash-feature-set": "WF_NoDelete",
               "content-type": "application/json",
               "upstash-forward-upstash-workflow-sdk-version": "1",
               "upstash-method": "POST",
@@ -185,6 +186,7 @@ describe("context tests", () => {
             },
             timeout: "20s",
             timeoutHeaders: {
+              "Upstash-Feature-Set": ["WF_NoDelete"],
               "Content-Type": ["application/json"],
               [`Upstash-Forward-${WORKFLOW_PROTOCOL_VERSION_HEADER}`]: ["1"],
               "Upstash-Retries": ["3"],
@@ -234,6 +236,7 @@ describe("context tests", () => {
               body: '{"stepId":0,"stepName":"my-wait-step","stepType":"Wait","waitEventId":"my-event-id","timeout":"20s","concurrent":2,"targetStep":1}',
               destination: WORKFLOW_ENDPOINT,
               headers: {
+                "upstash-feature-set": "WF_NoDelete",
                 "content-type": "application/json",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",
@@ -248,6 +251,7 @@ describe("context tests", () => {
               body: '{"stepId":0,"stepName":"my-run-step","stepType":"Run","concurrent":2,"targetStep":2}',
               destination: WORKFLOW_ENDPOINT,
               headers: {
+                "upstash-feature-set": "WF_NoDelete",
                 "content-type": "application/json",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",

--- a/src/context/context.test.ts
+++ b/src/context/context.test.ts
@@ -95,7 +95,7 @@ describe("context tests", () => {
 
     const throws = async () => {
       await context.run("outer step", async () => {
-        await context.call("inner call", "https://some-url.com", "GET");
+        await context.call("inner call", { url: "https://some-url.com"});
       });
     };
     expect(throws).toThrow(

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -279,13 +279,23 @@ export class WorkflowContext<TInitialPayload = unknown> {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
   public async call<TResult = unknown, TBody = unknown>(
     stepName: string,
-    url: string,
-    method: HTTPMethods,
-    body?: TBody,
-    headers?: Record<string, string>
+    callSettings: {
+      url: string,
+      method?: HTTPMethods,
+      body?: TBody,
+      headers?: Record<string, string>
+    }
   ) {
+
+    const {
+      url,
+      method = "GET",
+      body,
+      headers = {}
+    } = callSettings;
+
     const result = await this.addStep(
-      new LazyCallStep<string>(stepName, url, method, body, headers ?? {})
+      new LazyCallStep<string>(stepName, url, method, body, headers )
     );
 
     try {

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -1,4 +1,4 @@
-import type { WaitStepResponse, WorkflowClient } from "../types";
+import type { CallResponse, WaitStepResponse, WorkflowClient } from "../types";
 import { type StepFunction, type Step } from "../types";
 import { AutoExecutor } from "./auto-executor";
 import type { BaseLazyStep } from "./steps";
@@ -277,32 +277,21 @@ export class WorkflowContext<TInitialPayload = unknown> {
    * @returns call result (parsed as JSON if possible)
    */
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
-  public async call<TResult = unknown, TBody = unknown>(
+  public async call(
     stepName: string,
     callSettings: {
-      url: string,
-      method?: HTTPMethods,
-      body?: TBody,
-      headers?: Record<string, string>
+      url: string;
+      method?: HTTPMethods;
+      body?: unknown;
+      headers?: Record<string, string>;
     }
   ) {
-
-    const {
-      url,
-      method = "GET",
-      body,
-      headers = {}
-    } = callSettings;
+    const { url, method = "GET", body, headers = {} } = callSettings;
 
     const result = await this.addStep(
-      new LazyCallStep<string>(stepName, url, method, body, headers )
+      new LazyCallStep<CallResponse>(stepName, url, method, body, headers)
     );
-
-    try {
-      return JSON.parse(result) as TResult;
-    } catch {
-      return result as TResult;
-    }
+    return result;
   }
 
   public async waitForEvent(

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -394,10 +394,12 @@ describe.skip("live serve tests", () => {
 
           const postResult = await context.call<string>(
             "post call",
-            LOCAL_THIRD_PARTY_URL,
-            "POST",
-            "post-payload",
-            postHeader
+            {
+              url: LOCAL_THIRD_PARTY_URL,
+              method: "POST",
+              body: "post-payload",
+              headers: postHeader
+            }
           );
           expect(postResult).toBe(
             "called POST 'third-party-result' 'post-header-value-x' '\"post-payload\"'"
@@ -407,10 +409,10 @@ describe.skip("live serve tests", () => {
 
           const getResult = await context.call<string>(
             "get call",
-            LOCAL_THIRD_PARTY_URL,
-            "GET",
-            undefined,
-            getHeader
+            {
+              url: LOCAL_THIRD_PARTY_URL,
+              headers: getHeader
+            }
           );
 
           expect(getResult).toBe("called GET 'third-party-result' 'get-header-value-x'");

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -392,28 +392,22 @@ describe.skip("live serve tests", () => {
             return;
           }
 
-          const postResult = await context.call<string>(
-            "post call",
-            {
-              url: LOCAL_THIRD_PARTY_URL,
-              method: "POST",
-              body: "post-payload",
-              headers: postHeader
-            }
-          );
+          const { body: postResult } = await context.call("post call", {
+            url: LOCAL_THIRD_PARTY_URL,
+            method: "POST",
+            body: "post-payload",
+            headers: postHeader,
+          });
           expect(postResult).toBe(
             "called POST 'third-party-result' 'post-header-value-x' '\"post-payload\"'"
           );
 
           await context.sleep("sleep 1", 2);
 
-          const getResult = await context.call<string>(
-            "get call",
-            {
-              url: LOCAL_THIRD_PARTY_URL,
-              headers: getHeader
-            }
-          );
+          const { body: getResult } = await context.call("get call", {
+            url: LOCAL_THIRD_PARTY_URL,
+            headers: getHeader,
+          });
 
           expect(getResult).toBe("called GET 'third-party-result' 'get-header-value-x'");
           finishState.finish();
@@ -494,6 +488,46 @@ describe.skip("live serve tests", () => {
     },
     {
       timeout: 10_000,
+    }
+  );
+
+  test(
+    "call failure",
+    async () => {
+      const failingResponse = "failing-response";
+      const payload = "my-payload";
+      const thirdPartyServer = serve({
+        async fetch(request) {
+          const requestPayload = await request.json();
+          return new Response(`${failingResponse} - ${requestPayload}`, { status: 400 });
+        },
+        port: THIRD_PARTY_PORT,
+      });
+
+      const finishState = new FinishState();
+      await testEndpoint({
+        finalCount: 4,
+        waitFor: 7000,
+        initialPayload: payload,
+        finishState,
+        routeFunction: async (context) => {
+          const input = context.requestPayload;
+          const { status, body, header } = await context.call("failing call", {
+            url: LOCAL_THIRD_PARTY_URL,
+            body: input,
+            method: "POST",
+          });
+          expect(status).toBe(400);
+          expect(body).toBe(`${failingResponse} - ${payload}`);
+          expect(header["Content-Length"]).toEqual(["29"]);
+          finishState.finish();
+        },
+      });
+
+      thirdPartyServer.stop();
+    },
+    {
+      timeout: 8000,
     }
   );
 

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -120,7 +120,7 @@ const testEndpoint = async <TInitialPayload = unknown>({
 }) => {
   let counter = 0;
 
-  const endpoint = workflowServe<TInitialPayload>(routeFunction, {
+  const { POST: endpoint } = workflowServe<TInitialPayload>(routeFunction, {
     qstashClient,
     url: LOCAL_WORKFLOW_URL,
     verbose: true,

--- a/src/receiver.test.ts
+++ b/src/receiver.test.ts
@@ -83,7 +83,7 @@ const receiver = new Receiver({ currentSigningKey, nextSigningKey });
 /**
  * endpoint to call in the receiver tests
  */
-const endpoint = serve(
+const { handler: endpoint } = serve(
   async (context) => {
     await context.run("step 1", () => {
       return "result";

--- a/src/serve/authorization.test.ts
+++ b/src/serve/authorization.test.ts
@@ -74,7 +74,7 @@ describe("disabled workflow context", () => {
       let called = false;
       await mockQStashServer({
         execute: () => {
-          const throws = disabledContext.call("call-step", "some-url", "GET");
+          const throws = disabledContext.call("call-step", { url: "some-url"});
           expect(throws).rejects.toThrow(QStashWorkflowAbort);
           called = true;
         },

--- a/src/serve/authorization.test.ts
+++ b/src/serve/authorization.test.ts
@@ -74,7 +74,7 @@ describe("disabled workflow context", () => {
       let called = false;
       await mockQStashServer({
         execute: () => {
-          const throws = disabledContext.call("call-step", { url: "some-url"});
+          const throws = disabledContext.call("call-step", { url: "some-url" });
           expect(throws).rejects.toThrow(QStashWorkflowAbort);
           called = true;
         },
@@ -200,6 +200,7 @@ describe("disabled workflow context", () => {
               body: '{"stepId":1,"stepName":"step","stepType":"Run","out":"result","concurrent":1}',
               destination: WORKFLOW_ENDPOINT,
               headers: {
+                "upstash-feature-set": "WF_NoDelete",
                 "content-type": "application/json",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",
@@ -247,6 +248,7 @@ describe("disabled workflow context", () => {
               body: '{"stepId":1,"stepName":"step","stepType":"Run","out":"result","concurrent":1}',
               destination: WORKFLOW_ENDPOINT,
               headers: {
+                "upstash-feature-set": "WF_NoDelete",
                 "content-type": "application/json",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",
@@ -295,6 +297,7 @@ describe("disabled workflow context", () => {
               body: '{"stepId":1,"stepName":"step","stepType":"Run","out":"result","concurrent":1}',
               destination: WORKFLOW_ENDPOINT,
               headers: {
+                "upstash-feature-set": "WF_NoDelete",
                 "content-type": "application/json",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",

--- a/src/serve/index.ts
+++ b/src/serve/index.ts
@@ -29,7 +29,7 @@ export const serve = <
 >(
   routeFunction: RouteFunction<TInitialPayload>,
   options?: WorkflowServeOptions<TResponse, TInitialPayload>
-): { handler: ((request: TRequest) => Promise<TResponse>) } => {
+): { handler: (request: TRequest) => Promise<TResponse> } => {
   // Prepares options with defaults if they are not provided.
   const {
     qstashClient,
@@ -184,5 +184,5 @@ export const serve = <
     }
   };
 
-  return { handler: safeHandler }
+  return { handler: safeHandler };
 };

--- a/src/serve/index.ts
+++ b/src/serve/index.ts
@@ -56,6 +56,8 @@ export const serve = <
    * @returns A promise that resolves to a response.
    */
   const handler = async (request: TRequest) => {
+    await debug?.log("INFO", "ENDPOINT_START");
+
     const { workflowUrl, workflowFailureUrl } = await determineUrls(
       request,
       url,
@@ -114,6 +116,7 @@ export const serve = <
       failureUrl: workflowFailureUrl,
       debug,
       env,
+      retries,
     });
 
     // attempt running routeFunction until the first step

--- a/src/serve/index.ts
+++ b/src/serve/index.ts
@@ -29,7 +29,7 @@ export const serve = <
 >(
   routeFunction: RouteFunction<TInitialPayload>,
   options?: WorkflowServeOptions<TResponse, TInitialPayload>
-): ((request: TRequest) => Promise<TResponse>) => {
+): { handler: ((request: TRequest) => Promise<TResponse>) } => {
   // Prepares options with defaults if they are not provided.
   const {
     qstashClient,
@@ -173,7 +173,7 @@ export const serve = <
     return onStepFinish("no-workflow-id", "fromCallback");
   };
 
-  return async (request: TRequest) => {
+  const safeHandler = async (request: TRequest) => {
     try {
       return await handler(request);
     } catch (error) {
@@ -183,4 +183,6 @@ export const serve = <
       }) as TResponse;
     }
   };
+
+  return { handler: safeHandler }
 };

--- a/src/serve/serve.test.ts
+++ b/src/serve/serve.test.ts
@@ -325,6 +325,7 @@ describe("serve", () => {
               destination: WORKFLOW_ENDPOINT,
               headers: {
                 "content-type": "application/json",
+                "upstash-feature-set": "WF_NoDelete",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",
                 "upstash-retries": "3",

--- a/src/serve/serve.test.ts
+++ b/src/serve/serve.test.ts
@@ -30,7 +30,7 @@ const qstashClient = new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token });
 
 describe("serve", () => {
   test("should send create workflow request in initial request", async () => {
-    const endpoint = serve<string>(
+    const { handler: endpoint } = serve<string>(
       async (context) => {
         const _input = context.requestPayload;
         await context.sleep("sleep 1", 1);
@@ -67,7 +67,7 @@ describe("serve", () => {
   });
 
   test("path endpoint", async () => {
-    const endpoint = serve<string>(
+    const { handler: endpoint } = serve<string>(
       async (context) => {
         const input = context.requestPayload;
 
@@ -179,7 +179,7 @@ describe("serve", () => {
   });
 
   test("should return 500 on error during step execution", async () => {
-    const endpoint = serve(
+    const { handler: endpoint } = serve(
       async (context) => {
         await context.run("wrong step", async () => {
           throw new Error("some-error");
@@ -213,7 +213,7 @@ describe("serve", () => {
   });
 
   test("should call onFinish with auth-fail if authentication fails", async () => {
-    const endpoint = serve(
+    const { handler: endpoint } = serve(
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       async (_context) => {
         // we call `return` when auth fails:
@@ -248,7 +248,7 @@ describe("serve", () => {
   });
 
   describe("duplicate checks", () => {
-    const endpoint = serve(
+    const { handler: endpoint } = serve(
       async (context) => {
         const result1 = await context.run("step 1", () => {
           return "result 1";
@@ -348,7 +348,7 @@ describe("serve", () => {
 
     test("should not have failureUrl if failureUrl or failureFunction is not passed", async () => {
       const request = getRequest(WORKFLOW_ENDPOINT, "wfr-bar", "my-payload", []);
-      const endpoint = serve(routeFunction, {
+      const { handler: endpoint } = serve(routeFunction, {
         qstashClient,
         receiver: undefined,
       });
@@ -387,7 +387,7 @@ describe("serve", () => {
     test("should set failureUrl if failureUrl is passed", async () => {
       const request = getRequest(WORKFLOW_ENDPOINT, "wfr-bar", "my-payload", []);
       const myFailureEndpoint = "https://www.my-failure-endpoint.com/api";
-      const endpoint = serve(routeFunction, {
+      const { handler: endpoint } = serve(routeFunction, {
         qstashClient,
         receiver: undefined,
         failureUrl: myFailureEndpoint,
@@ -436,7 +436,7 @@ describe("serve", () => {
       ) => {
         return;
       };
-      const endpoint = serve(routeFunction, {
+      const { handler: endpoint } = serve(routeFunction, {
         qstashClient,
         receiver: undefined,
         failureFunction: myFailureFunction,
@@ -489,7 +489,7 @@ describe("serve", () => {
         },
       });
       let called = false;
-      const endpoint = serve(
+      const { handler: endpoint } = serve(
         async (context) => {
           expect(context.url).toBe(contextUrl);
           called = true;
@@ -542,7 +542,7 @@ describe("serve", () => {
       },
     });
     let called = false;
-    const endpoint = serve(
+    const { handler: endpoint } = serve(
       async (context) => {
         expect(context.env["env-var-1"]).toBe("value-1");
         expect(context.env["env-var-2"]).toBe("value-2");

--- a/src/types.ts
+++ b/src/types.ts
@@ -269,3 +269,9 @@ export type WaitStepResponse = {
   timeout: boolean;
   notifyBody: unknown;
 };
+
+export type CallResponse = {
+  status: number;
+  body: unknown;
+  header: Record<string, string[]>;
+};

--- a/src/workflow-requests.test.ts
+++ b/src/workflow-requests.test.ts
@@ -16,6 +16,7 @@ import { Client } from "@upstash/qstash";
 import type { Step, StepType } from "./types";
 import {
   WORKFLOW_FAILURE_HEADER,
+  WORKFLOW_FEATURE_HEADER,
   WORKFLOW_ID_HEADER,
   WORKFLOW_INIT_HEADER,
   WORKFLOW_PROTOCOL_VERSION,
@@ -192,7 +193,7 @@ describe("Workflow Requests", () => {
             WORKFLOW_ENDPOINT,
             2
           );
-          expect(result.isOk());
+          expect(result.isOk()).toBeTrue();
           // @ts-expect-error value will be set since stepFinish isOk
           expect(result.value).toBe("is-call-return");
         },
@@ -208,7 +209,10 @@ describe("Workflow Requests", () => {
             stepId: 3,
             stepName: stepName,
             stepType: stepType,
-            out: thirdPartyCallResult,
+            out: {
+              body: thirdPartyCallResult,
+              status: 200,
+            },
             concurrent: 1,
           },
           headers: {
@@ -227,14 +231,19 @@ describe("Workflow Requests", () => {
 
       // status set to 404 which should make QStash retry. workflow sdk should do nothing
       // in this case
-      const requestPayload = { status: 404, body: btoa(thirdPartyCallResult) };
+      const requestPayload = {
+        status: 404,
+        body: btoa(thirdPartyCallResult),
+        maxRetries: 3,
+        retried: 1,
+      };
       const stepName = "test step";
       const stepType: StepType = "Run";
       const workflowRunId = nanoid();
 
       // create client
       const token = "myToken";
-      const client = new Client({ baseUrl: MOCK_SERVER_URL, token });
+      const client = new Client({ baseUrl: MOCK_QSTASH_SERVER_URL, token });
 
       // create the request which will be received by the serve method:
       const request = new Request(WORKFLOW_ENDPOINT, {
@@ -310,7 +319,7 @@ describe("Workflow Requests", () => {
         WORKFLOW_ENDPOINT,
         5
       );
-      expect(initialResult.isOk());
+      expect(initialResult.isOk()).toBeTrue();
       // @ts-expect-error value will be set since stepFinish isOk
       expect(initialResult.value).toBe("continue-workflow");
       expect(spy).toHaveBeenCalledTimes(0);
@@ -336,6 +345,7 @@ describe("Workflow Requests", () => {
     test("should create headers without step passed", () => {
       const { headers, timeoutHeaders } = getHeaders("true", workflowRunId, WORKFLOW_ENDPOINT);
       expect(headers).toEqual({
+        [WORKFLOW_FEATURE_HEADER]: "WF_NoDelete",
         [WORKFLOW_INIT_HEADER]: "true",
         [WORKFLOW_ID_HEADER]: workflowRunId,
         [WORKFLOW_URL_HEADER]: WORKFLOW_ENDPOINT,
@@ -362,6 +372,7 @@ describe("Workflow Requests", () => {
         }
       );
       expect(headers).toEqual({
+        [WORKFLOW_FEATURE_HEADER]: "WF_NoDelete",
         [WORKFLOW_INIT_HEADER]: "false",
         [WORKFLOW_ID_HEADER]: workflowRunId,
         [WORKFLOW_URL_HEADER]: WORKFLOW_ENDPOINT,
@@ -398,11 +409,12 @@ describe("Workflow Requests", () => {
         }
       );
       expect(headers).toEqual({
+        [WORKFLOW_FEATURE_HEADER]: "WF_NoDelete",
         [WORKFLOW_INIT_HEADER]: "false",
         [WORKFLOW_ID_HEADER]: workflowRunId,
         [WORKFLOW_URL_HEADER]: WORKFLOW_ENDPOINT,
         [`Upstash-Forward-${WORKFLOW_PROTOCOL_VERSION_HEADER}`]: WORKFLOW_PROTOCOL_VERSION,
-
+        "Upstash-Retries": "0",
         "Upstash-Callback": WORKFLOW_ENDPOINT,
         "Upstash-Callback-Forward-Upstash-Workflow-Callback": "true",
         "Upstash-Callback-Forward-Upstash-Workflow-Concurrent": "1",
@@ -431,6 +443,7 @@ describe("Workflow Requests", () => {
         failureUrl
       );
       expect(headers).toEqual({
+        [WORKFLOW_FEATURE_HEADER]: "WF_NoDelete",
         [WORKFLOW_INIT_HEADER]: "true",
         [WORKFLOW_ID_HEADER]: workflowRunId,
         [WORKFLOW_URL_HEADER]: WORKFLOW_ENDPOINT,
@@ -457,6 +470,7 @@ describe("Workflow Requests", () => {
         }
       );
       expect(headers).toEqual({
+        [WORKFLOW_FEATURE_HEADER]: "WF_NoDelete",
         "Upstash-Workflow-Init": "false",
         "Upstash-Workflow-RunId": workflowRunId,
         "Upstash-Workflow-Url": WORKFLOW_ENDPOINT,
@@ -464,6 +478,7 @@ describe("Workflow Requests", () => {
         "Upstash-Workflow-CallType": "step",
       });
       expect(timeoutHeaders).toEqual({
+        [WORKFLOW_FEATURE_HEADER]: ["WF_NoDelete"],
         "Upstash-Workflow-Init": ["false"],
         "Upstash-Workflow-RunId": [workflowRunId],
         "Upstash-Workflow-Url": [WORKFLOW_ENDPOINT],

--- a/src/workflow-requests.ts
+++ b/src/workflow-requests.ts
@@ -5,6 +5,7 @@ import type { WorkflowContext } from "./context";
 import {
   DEFAULT_CONTENT_TYPE,
   WORKFLOW_FAILURE_HEADER,
+  WORKFLOW_FEATURE_HEADER,
   WORKFLOW_ID_HEADER,
   WORKFLOW_INIT_HEADER,
   WORKFLOW_PROTOCOL_VERSION,
@@ -12,6 +13,7 @@ import {
   WORKFLOW_URL_HEADER,
 } from "./constants";
 import type {
+  CallResponse,
   Step,
   StepType,
   WorkflowClient,
@@ -149,10 +151,17 @@ export const handleThirdPartyCallResult = async (
       const callbackMessage = JSON.parse(requestPayload) as {
         status: number;
         body: string;
+        retried?: number; // only set after the first try
+        maxRetries: number;
+        header: Record<string, string[]>;
       };
 
       // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-      if (!(callbackMessage.status >= 200 && callbackMessage.status < 300)) {
+      if (
+        !(callbackMessage.status >= 200 && callbackMessage.status < 300) &&
+        callbackMessage.maxRetries &&
+        callbackMessage.retried !== callbackMessage.maxRetries
+      ) {
         await debug?.log("WARN", "SUBMIT_THIRD_PARTY_RESULT", {
           status: callbackMessage.status,
           body: atob(callbackMessage.body),
@@ -160,7 +169,7 @@ export const handleThirdPartyCallResult = async (
         // this callback will be retried by the QStash, we just ignore it
         console.warn(
           `Workflow Warning: "context.call" failed with status ${callbackMessage.status}` +
-            ` and will retry (if there are retries remaining).` +
+            ` and will retry (retried ${callbackMessage.retried ?? 0} out of ${callbackMessage.maxRetries} times).` +
             ` Error Message:\n${atob(callbackMessage.body)}`
         );
         return ok("call-will-retry");
@@ -206,11 +215,15 @@ export const handleThirdPartyCallResult = async (
         retries
       );
 
-      const callResultStep: Step = {
+      const callResultStep: Step<CallResponse> = {
         stepId: Number(stepIdString),
         stepName,
         stepType,
-        out: atob(callbackMessage.body),
+        out: {
+          status: callbackMessage.status,
+          body: atob(callbackMessage.body),
+          header: callbackMessage.header,
+        },
         concurrent: Number(concurrentString),
       };
 
@@ -273,19 +286,30 @@ export const getHeaders = (
     [WORKFLOW_INIT_HEADER]: initHeaderValue,
     [WORKFLOW_ID_HEADER]: workflowRunId,
     [WORKFLOW_URL_HEADER]: workflowUrl,
+    [WORKFLOW_FEATURE_HEADER]: "WF_NoDelete",
     [`Upstash-Forward-${WORKFLOW_PROTOCOL_VERSION_HEADER}`]: WORKFLOW_PROTOCOL_VERSION,
-    ...(failureUrl
-      ? {
-          [`Upstash-Failure-Callback-Forward-${WORKFLOW_FAILURE_HEADER}`]: "true",
-          "Upstash-Failure-Callback": failureUrl,
-        }
-      : {}),
-    ...(retries === undefined
-      ? {}
-      : {
-          "Upstash-Retries": retries.toString(),
-        }),
   };
+
+  if (failureUrl) {
+    if (!step?.callUrl) {
+      baseHeaders[`Upstash-Failure-Callback-Forward-${WORKFLOW_FAILURE_HEADER}`] = "true";
+    }
+    baseHeaders["Upstash-Failure-Callback"] = failureUrl;
+  }
+
+  // if retries is set or if call url is passed, set a retry
+  // for call url, retry is 0
+  if (step?.callUrl) {
+    baseHeaders["Upstash-Retries"] = "0";
+
+    // if some retries is set, use it in callback and failure callback
+    if (retries) {
+      baseHeaders["Upstash-Callback-Retries"] = retries.toString();
+      baseHeaders["Upstash-Failure-Callback-Retries"] = retries.toString();
+    }
+  } else if (retries !== undefined) {
+    baseHeaders["Upstash-Retries"] = retries.toString();
+  }
 
   if (userHeaders) {
     for (const header of userHeaders.keys()) {


### PR DESCRIPTION
as we migrate from @upstash/qstash, there are some backwards incompatible changes we want to make.

These will be explained in the migration guide. To briefly explain them here:
- change serve method returns to allow `const { POST } = serve(...)`
- update context.call parameters and return
```ts
// old
const result = await context.call("call step", "<call-url>", "POST", ...)

// new
const {
  status,  // response status
  headers, // response headers
  body     // response body
} = await context.call("call step", {
  url: "<call-url>",
  method: "POST",
  ...
})
```