### PR TITLE
Stringify/parse step.out

### DIFF
--- a/src/context/auto-executor.test.ts
+++ b/src/context/auto-executor.test.ts
@@ -129,7 +129,10 @@ describe("auto-executor", () => {
                 "upstash-workflow-init": "false",
                 "upstash-workflow-url": WORKFLOW_ENDPOINT,
               },
-              body: JSON.stringify(singleStep),
+              body: JSON.stringify({
+                ...singleStep,
+                out: JSON.stringify(singleStep.out),
+              }),
             },
           ],
         },

--- a/src/context/auto-executor.ts
+++ b/src/context/auto-executor.ts
@@ -356,7 +356,7 @@ export class AutoExecutor {
         body: JSON.stringify(waitBody),
         headers,
         method: "POST",
-        parseResponseAsJson: false
+        parseResponseAsJson: false,
       });
 
       throw new QStashWorkflowAbort(steps[0].stepName, steps[0]);
@@ -376,6 +376,8 @@ export class AutoExecutor {
 
         // if the step is a single step execution or a plan step, we can add sleep headers
         const willWait = singleStep.concurrent === NO_CONCURRENCY || singleStep.stepId === 0;
+
+        singleStep.out = JSON.stringify(singleStep.out);
 
         return singleStep.callUrl
           ? // if the step is a third party call, we call the third party

--- a/src/context/context.test.ts
+++ b/src/context/context.test.ts
@@ -134,7 +134,7 @@ describe("context tests", () => {
         token,
         body: [
           {
-            body: '{"stepId":1,"stepName":"my-step","stepType":"Run","out":"my-result","concurrent":1}',
+            body: '{"stepId":1,"stepName":"my-step","stepType":"Run","out":"\\"my-result\\"","concurrent":1}',
             destination: WORKFLOW_ENDPOINT,
             headers: {
               "upstash-feature-set": "WF_NoDelete",

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -125,7 +125,7 @@ const testEndpoint = async <TInitialPayload = unknown>({
   const { POST: endpoint } = workflowServe<TInitialPayload>(routeFunction, {
     qstashClient,
     url: `http://localhost:${port}`,
-    // verbose: true,
+    verbose: true,
     failureFunction,
     retries,
   });

--- a/src/serve/authorization.test.ts
+++ b/src/serve/authorization.test.ts
@@ -197,7 +197,13 @@ describe("disabled workflow context", () => {
           token,
           body: [
             {
-              body: '{"stepId":1,"stepName":"step","stepType":"Run","out":"result","concurrent":1}',
+              body: JSON.stringify({
+                stepId: 1,
+                stepName: "step",
+                stepType: "Run",
+                out: '"result"',
+                concurrent: 1,
+              }),
               destination: WORKFLOW_ENDPOINT,
               headers: {
                 "upstash-feature-set": "WF_NoDelete",
@@ -245,7 +251,13 @@ describe("disabled workflow context", () => {
           token,
           body: [
             {
-              body: '{"stepId":1,"stepName":"step","stepType":"Run","out":"result","concurrent":1}',
+              body: JSON.stringify({
+                stepId: 1,
+                stepName: "step",
+                stepType: "Run",
+                out: '"result"',
+                concurrent: 1,
+              }),
               destination: WORKFLOW_ENDPOINT,
               headers: {
                 "upstash-feature-set": "WF_NoDelete",
@@ -294,7 +306,13 @@ describe("disabled workflow context", () => {
           token,
           body: [
             {
-              body: '{"stepId":1,"stepName":"step","stepType":"Run","out":"result","concurrent":1}',
+              body: JSON.stringify({
+                stepId: 1,
+                stepName: "step",
+                stepType: "Run",
+                out: '"result"',
+                concurrent: 1,
+              }),
               destination: WORKFLOW_ENDPOINT,
               headers: {
                 "upstash-feature-set": "WF_NoDelete",

--- a/src/serve/serve.test.ts
+++ b/src/serve/serve.test.ts
@@ -49,7 +49,8 @@ describe("serve", () => {
     });
     await mockQStashServer({
       execute: async () => {
-        await endpoint(request);
+        const response = await endpoint(request);
+        expect(response.status).toBe(200);
       },
       responseFields: { body: "msgId", status: 200 },
       receivesRequest: {
@@ -93,14 +94,14 @@ describe("serve", () => {
         stepId: 1,
         stepName: "step1",
         stepType: "Run",
-        out: `processed '${initialPayload}'`,
+        out: JSON.stringify(`processed '${initialPayload}'`),
         concurrent: 1,
       },
       {
         stepId: 2,
         stepName: "step2",
         stepType: "Run",
-        out: `processed 'processed '${initialPayload}''`,
+        out: JSON.stringify(`processed 'processed '${initialPayload}''`),
         concurrent: 1,
       },
     ];
@@ -108,7 +109,8 @@ describe("serve", () => {
     await driveWorkflow({
       execute: async (initialPayload, steps) => {
         const request = getRequest(WORKFLOW_ENDPOINT, workflowRunId, initialPayload, steps);
-        await endpoint(request);
+        const response = await endpoint(request);
+        expect(response.status).toBe(200);
       },
       initialPayload,
       iterations: [
@@ -129,6 +131,7 @@ describe("serve", () => {
                 headers: {
                   "content-type": "application/json",
                   "upstash-forward-upstash-workflow-sdk-version": "1",
+                  "upstash-feature-set": "WF_NoDelete",
                   "upstash-retries": "3",
                   "upstash-method": "POST",
                   "upstash-workflow-runid": workflowRunId,
@@ -155,6 +158,7 @@ describe("serve", () => {
                 headers: {
                   "content-type": "application/json",
                   "upstash-forward-upstash-workflow-sdk-version": "1",
+                  "upstash-feature-set": "WF_NoDelete",
                   "upstash-method": "POST",
                   "upstash-retries": "3",
                   "upstash-workflow-runid": workflowRunId,
@@ -335,7 +339,7 @@ describe("serve", () => {
                 "upstash-workflow-runid": "wfr-foo",
                 "upstash-workflow-url": WORKFLOW_ENDPOINT,
               },
-              body: '{"stepId":3,"stepName":"step 3","stepType":"Run","out":"combined results: result 1,result 2","concurrent":1}',
+              body: '{"stepId":3,"stepName":"step 3","stepType":"Run","out":"\\"combined results: result 1,result 2\\"","concurrent":1}',
             },
           ],
         },
@@ -358,7 +362,8 @@ describe("serve", () => {
       let called = false;
       await mockQStashServer({
         execute: async () => {
-          await endpoint(request);
+          const result = await endpoint(request);
+          expect(result.status).toBe(200);
           called = true;
         },
         responseFields: { body: { messageId: "some-message-id" }, status: 200 },
@@ -372,6 +377,7 @@ describe("serve", () => {
               headers: {
                 "content-type": "application/json",
                 "upstash-delay": "1s",
+                "upstash-feature-set": "WF_NoDelete",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",
                 "upstash-retries": "3",
@@ -398,7 +404,8 @@ describe("serve", () => {
       let called = false;
       await mockQStashServer({
         execute: async () => {
-          await endpoint(request);
+          const response = await endpoint(request);
+          expect(response.status).toBe(200);
           called = true;
         },
         responseFields: { body: { messageId: "some-message-id" }, status: 200 },
@@ -415,6 +422,7 @@ describe("serve", () => {
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",
                 "upstash-retries": "3",
+                "upstash-feature-set": "WF_NoDelete",
                 "upstash-workflow-init": "false",
                 "upstash-workflow-runid": "wfr-bar",
                 "upstash-workflow-url": WORKFLOW_ENDPOINT,
@@ -446,7 +454,8 @@ describe("serve", () => {
       });
       await mockQStashServer({
         execute: async () => {
-          await endpoint(request);
+          const response = await endpoint(request);
+          expect(response.status).toBe(200);
           called = true;
         },
         responseFields: { body: { messageId: "some-message-id" }, status: 200 },
@@ -463,6 +472,7 @@ describe("serve", () => {
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",
                 "upstash-retries": "3",
+                "upstash-feature-set": "WF_NoDelete",
                 "upstash-workflow-init": "false",
                 "upstash-workflow-runid": "wfr-bar",
                 "upstash-workflow-url": WORKFLOW_ENDPOINT,

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -121,7 +121,7 @@ export const driveWorkflow = async ({
   for (const { stepsToAdd, responseFields, receivesRequest } of iterations) {
     steps.push(...stepsToAdd);
     await mockQStashServer({
-      execute: () => execute(initialPayload, steps),
+      execute: async () => execute(initialPayload, steps),
       responseFields,
       receivesRequest,
     });

--- a/src/workflow-parser.test.ts
+++ b/src/workflow-parser.test.ts
@@ -331,10 +331,10 @@ describe("Workflow Parser", () => {
     test("target step duplicated at the end", async () => {
       // prettier-ignore
       const requestSteps: Step[] = [
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  '"false"', concurrent: 1},
         {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5},
-        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1},
+        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  '"true"', concurrent: 1},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5}, // duplicate
       ]
 
@@ -362,12 +362,12 @@ describe("Workflow Parser", () => {
     test("target step duplicated in the middle", async () => {
       // prettier-ignore
       const requestSteps: Step[] = [
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  '"false"', concurrent: 1},
         {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
-        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1},
+        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  '"true"', concurrent: 1},
         {stepId: 0, stepName: "successStep1", stepType: "Run", concurrent: 2, targetStep: 4},
         {stepId: 0, stepName: "successStep1", stepType: "Run", concurrent: 2, targetStep: 4}, // duplicate
-        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  "10", concurrent: 2},
+        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  '"10"', concurrent: 2},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5},
       ]
 
@@ -397,9 +397,9 @@ describe("Workflow Parser", () => {
     test("concurrent step result duplicated", async () => {
       // prettier-ignore
       const requestSteps: Step[] = [
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out: "false", concurrent: 1},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out: '"false"', concurrent: 1},
         {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
-        {stepId: 3, stepName: "chargeStep", stepType: "Run", out: "true", concurrent: 1},
+        {stepId: 3, stepName: "chargeStep", stepType: "Run", out: '"true"', concurrent: 1},
         {stepId: 0, stepName: "successStep1", stepType: "Run", concurrent: 2, targetStep: 4},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5},
         {stepId: 5, stepName: "successStep2", stepType: "Run", out: "20", concurrent: 2},
@@ -425,7 +425,7 @@ describe("Workflow Parser", () => {
         {stepId: 3, stepName: "chargeStep", stepType: "Run", out: "true", concurrent: 1},
         {stepId: 0, stepName: "successStep1", stepType: "Run", concurrent: 2, targetStep: 4},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5},
-        {stepId: 5, stepName: "successStep2", stepType: "Run", out: "20", concurrent: 2},
+        {stepId: 5, stepName: "successStep2", stepType: "Run", out: 20, concurrent: 2},
       ])
     });
 
@@ -436,10 +436,10 @@ describe("Workflow Parser", () => {
         {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
         {stepId: 3, stepName: "chargeStep", stepType: "Run", out: "true", concurrent: 1},
         {stepId: 0, stepName: "successStep1", stepType: "Run", concurrent: 2, targetStep: 4},
-        {stepId: 4, stepName: "successStep1", stepType: "Run", out: "10", concurrent: 2},
+        {stepId: 4, stepName: "successStep1", stepType: "Run", out: '"10"', concurrent: 2},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5},
-        {stepId: 5, stepName: "successStep2", stepType: "Run", out: "20", concurrent: 2},
-        {stepId: 5, stepName: "successStep2", stepType: "Run", out: "20", concurrent: 2}, // duplicate
+        {stepId: 5, stepName: "successStep2", stepType: "Run", out: '"20"', concurrent: 2},
+        {stepId: 5, stepName: "successStep2", stepType: "Run", out: '"20"', concurrent: 2}, // duplicate
       ]
 
       const request = getRequest(WORKFLOW_ENDPOINT, workflowId, requestPayload, requestSteps);
@@ -456,9 +456,9 @@ describe("Workflow Parser", () => {
       // prettier-ignore
       expect(steps).toEqual([
         initStep,
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out: "false", concurrent: 1},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out: false, concurrent: 1},
         {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
-        {stepId: 3, stepName: "chargeStep", stepType: "Run", out: "true", concurrent: 1},
+        {stepId: 3, stepName: "chargeStep", stepType: "Run", out: true, concurrent: 1},
         {stepId: 0, stepName: "successStep1", stepType: "Run", concurrent: 2, targetStep: 4},
         {stepId: 4, stepName: "successStep1", stepType: "Run", out: "10", concurrent: 2},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5},
@@ -469,7 +469,7 @@ describe("Workflow Parser", () => {
     test("result step duplicate", async () => {
       // prettier-ignore
       const requestSteps: Step[] = [
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  '"false"', concurrent: 1},
         {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
         {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1}, // duplicate
       ]
@@ -496,8 +496,8 @@ describe("Workflow Parser", () => {
     test("duplicate results in the middle", async () => {
       // prettier-ignore
       const requestSteps: Step[] = [
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1}, // duplicate
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  '"false"', concurrent: 1},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  '"false"', concurrent: 1}, // duplicate
         {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
       ]
 
@@ -523,21 +523,21 @@ describe("Workflow Parser", () => {
     test("all duplicated", async () => {
       // prettier-ignore
       const requestSteps: Step[] = [
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  '"false"', concurrent: 1},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  '"false"', concurrent: 1},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  '"false"', concurrent: 1},
         {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
         {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
-        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1},
-        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1},
+        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  '"true"', concurrent: 1},
+        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  '"true"', concurrent: 1},
         {stepId: 0, stepName: "successStep1", stepType: "Run", concurrent: 2, targetStep: 4},
         {stepId: 0, stepName: "successStep1", stepType: "Run", concurrent: 2, targetStep: 4},
-        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  "10", concurrent: 2},
-        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  "10", concurrent: 2},
+        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  '"10"', concurrent: 2},
+        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  '"10"', concurrent: 2},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5},
-        {stepId: 5, stepName: "successStep2", stepType: "Run", out:  "20", concurrent: 2},
-        {stepId: 5, stepName: "successStep2", stepType: "Run", out:  "20", concurrent: 2},
+        {stepId: 5, stepName: "successStep2", stepType: "Run", out:  '"20"', concurrent: 2},
+        {stepId: 5, stepName: "successStep2", stepType: "Run", out:  '"20"', concurrent: 2},
       ]
 
       const request = getRequest(WORKFLOW_ENDPOINT, workflowId, requestPayload, requestSteps);
@@ -567,20 +567,20 @@ describe("Workflow Parser", () => {
     test("all duplicated except last", async () => {
       // prettier-ignore
       const requestSteps: Step[] = [
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
-        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  "false", concurrent: 1},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  '"false"', concurrent: 1},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  '"false"', concurrent: 1},
+        {stepId: 1, stepName: "chargeStep", stepType: "Run", out:  '"false"', concurrent: 1},
         {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
         {stepId: 2, stepName: "retrySleep", stepType: "SleepFor", sleepFor: 1_000_000, concurrent: 1},
-        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1},
-        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  "true", concurrent: 1},
+        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  '"true"', concurrent: 1},
+        {stepId: 3, stepName: "chargeStep", stepType: "Run", out:  '"true"', concurrent: 1},
         {stepId: 0, stepName: "successStep1", stepType: "Run", concurrent: 2, targetStep: 4},
         {stepId: 0, stepName: "successStep1", stepType: "Run", concurrent: 2, targetStep: 4},
-        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  "10", concurrent: 2},
-        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  "10", concurrent: 2},
+        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  '"10"', concurrent: 2},
+        {stepId: 4, stepName: "successStep1", stepType: "Run", out:  '"10"', concurrent: 2},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5},
         {stepId: 0, stepName: "successStep2", stepType: "Run", concurrent: 2, targetStep: 5},
-        {stepId: 5, stepName: "successStep2", stepType: "Run", out:  "20", concurrent: 2},
+        {stepId: 5, stepName: "successStep2", stepType: "Run", out:  '"20"', concurrent: 2},
       ]
 
       const request = getRequest(WORKFLOW_ENDPOINT, workflowId, requestPayload, requestSteps);

--- a/src/workflow-parser.ts
+++ b/src/workflow-parser.ts
@@ -48,7 +48,7 @@ export const getPayload = async (request: Request) => {
  * @param rawPayload body of the request as a string as explained above
  * @returns intiial payload and list of steps
  */
-const parsePayload = (rawPayload: string) => {
+const parsePayload = async (rawPayload: string, debug?: WorkflowLogger) => {
   const [encodedInitialPayload, ...encodedSteps] = JSON.parse(rawPayload) as RawStep[];
 
   // decode initial payload:
@@ -65,20 +65,30 @@ const parsePayload = (rawPayload: string) => {
   const stepsToDecode = encodedSteps.filter((step) => step.callType === "step");
 
   // decode & parse other steps:
-  const otherSteps = stepsToDecode.map((rawStep) => {
-    const step = JSON.parse(decodeBase64(rawStep.body)) as Step;
+  const otherSteps = await Promise.all(
+    stepsToDecode.map(async (rawStep) => {
+      const step = JSON.parse(decodeBase64(rawStep.body)) as Step;
+      try {
+        step.out = JSON.parse(step.out as string);
+      } catch {
+        await debug?.log("WARN", "ENDPOINT_START", {
+          message: "failed while parsing out field of step",
+          step,
+        });
+      }
 
-    // if event is a wait event, overwrite the out with WaitStepResponse:
-    if (step.waitEventId) {
-      const newOut: WaitStepResponse = {
-        eventData: step.out,
-        timeout: step.waitTimeout ?? false,
-      };
-      step.out = newOut;
-    }
+      // if event is a wait event, overwrite the out with WaitStepResponse:
+      if (step.waitEventId) {
+        const newOut: WaitStepResponse = {
+          eventData: step.out,
+          timeout: step.waitTimeout ?? false,
+        };
+        step.out = newOut;
+      }
 
-    return step;
-  });
+      return step;
+    })
+  );
 
   // join and deduplicate steps:
   const steps: Step[] = [initialStep, ...otherSteps];
@@ -228,7 +238,7 @@ export const parseRequest = async (
     if (!requestPayload) {
       throw new QStashWorkflowError("Only first call can have an empty body");
     }
-    const { rawInitialPayload, steps } = parsePayload(requestPayload);
+    const { rawInitialPayload, steps } = await parsePayload(requestPayload, debug);
     const isLastDuplicate = await checkIfLastOneIsDuplicate(steps, debug);
     const deduplicatedSteps = deduplicateSteps(steps);
 

--- a/src/workflow-requests.test.ts
+++ b/src/workflow-requests.test.ts
@@ -209,10 +209,7 @@ describe("Workflow Requests", () => {
             stepId: 3,
             stepName: stepName,
             stepType: stepType,
-            out: {
-              body: thirdPartyCallResult,
-              status: 200,
-            },
+            out: '{"status":200,"body":"third-party-call-result"}',
             concurrent: 1,
           },
           headers: {

--- a/src/workflow-requests.ts
+++ b/src/workflow-requests.ts
@@ -215,15 +215,16 @@ export const handleThirdPartyCallResult = async (
         retries
       );
 
-      const callResultStep: Step<CallResponse> = {
+      const callResponse: CallResponse = {
+        status: callbackMessage.status,
+        body: atob(callbackMessage.body),
+        header: callbackMessage.header,
+      };
+      const callResultStep: Step<string> = {
         stepId: Number(stepIdString),
         stepName,
         stepType,
-        out: {
-          status: callbackMessage.status,
-          body: atob(callbackMessage.body),
-          header: callbackMessage.header,
-        },
+        out: JSON.stringify(callResponse),
         concurrent: Number(concurrentString),
       };
 


### PR DESCRIPTION
We now stringify whatever is in step.out before sending steps to QStash. Consequently, we parse the out field of incoming steps.