### PR TITLE
Fix Protocol and Feature Headers in context.call

### DIFF
--- a/src/context/auto-executor.test.ts
+++ b/src/context/auto-executor.test.ts
@@ -120,7 +120,6 @@ describe("auto-executor", () => {
             {
               destination: WORKFLOW_ENDPOINT,
               headers: {
-                "upstash-feature-set": "WF_NoDelete",
                 "content-type": "application/json",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",
@@ -211,7 +210,6 @@ describe("auto-executor", () => {
               body: '{"stepId":0,"stepName":"sleep for some time","stepType":"SleepFor","sleepFor":123,"concurrent":2,"targetStep":1}',
               destination: WORKFLOW_ENDPOINT,
               headers: {
-                "upstash-feature-set": "WF_NoDelete",
                 "content-type": "application/json",
                 "upstash-delay": "123s",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
@@ -226,7 +224,6 @@ describe("auto-executor", () => {
               body: '{"stepId":0,"stepName":"sleep until next day","stepType":"SleepUntil","sleepUntil":123123,"concurrent":2,"targetStep":2}',
               destination: WORKFLOW_ENDPOINT,
               headers: {
-                "upstash-feature-set": "WF_NoDelete",
                 "content-type": "application/json",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",
@@ -279,7 +276,6 @@ describe("auto-executor", () => {
             {
               destination: WORKFLOW_ENDPOINT,
               headers: {
-                "upstash-feature-set": "WF_NoDelete",
                 "content-type": "application/json",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",
@@ -332,7 +328,6 @@ describe("auto-executor", () => {
             {
               destination: WORKFLOW_ENDPOINT,
               headers: {
-                "upstash-feature-set": "WF_NoDelete",
                 "content-type": "application/json",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",

--- a/src/context/context.test.ts
+++ b/src/context/context.test.ts
@@ -137,7 +137,6 @@ describe("context tests", () => {
             body: '{"stepId":1,"stepName":"my-step","stepType":"Run","out":"\\"my-result\\"","concurrent":1}',
             destination: WORKFLOW_ENDPOINT,
             headers: {
-              "upstash-feature-set": "WF_NoDelete",
               "content-type": "application/json",
               "upstash-forward-upstash-workflow-sdk-version": "1",
               "upstash-method": "POST",
@@ -186,7 +185,6 @@ describe("context tests", () => {
             },
             timeout: "20s",
             timeoutHeaders: {
-              "Upstash-Feature-Set": ["WF_NoDelete"],
               "Content-Type": ["application/json"],
               [`Upstash-Forward-${WORKFLOW_PROTOCOL_VERSION_HEADER}`]: ["1"],
               "Upstash-Retries": ["3"],
@@ -236,7 +234,6 @@ describe("context tests", () => {
               body: '{"stepId":0,"stepName":"my-wait-step","stepType":"Wait","waitEventId":"my-event-id","timeout":"20s","concurrent":2,"targetStep":1}',
               destination: WORKFLOW_ENDPOINT,
               headers: {
-                "upstash-feature-set": "WF_NoDelete",
                 "content-type": "application/json",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",
@@ -251,7 +248,6 @@ describe("context tests", () => {
               body: '{"stepId":0,"stepName":"my-run-step","stepType":"Run","concurrent":2,"targetStep":2}',
               destination: WORKFLOW_ENDPOINT,
               headers: {
-                "upstash-feature-set": "WF_NoDelete",
                 "content-type": "application/json",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",

--- a/src/serve/authorization.test.ts
+++ b/src/serve/authorization.test.ts
@@ -206,7 +206,6 @@ describe("disabled workflow context", () => {
               }),
               destination: WORKFLOW_ENDPOINT,
               headers: {
-                "upstash-feature-set": "WF_NoDelete",
                 "content-type": "application/json",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",
@@ -260,7 +259,6 @@ describe("disabled workflow context", () => {
               }),
               destination: WORKFLOW_ENDPOINT,
               headers: {
-                "upstash-feature-set": "WF_NoDelete",
                 "content-type": "application/json",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",
@@ -315,7 +313,6 @@ describe("disabled workflow context", () => {
               }),
               destination: WORKFLOW_ENDPOINT,
               headers: {
-                "upstash-feature-set": "WF_NoDelete",
                 "content-type": "application/json",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",

--- a/src/serve/serve.test.ts
+++ b/src/serve/serve.test.ts
@@ -131,7 +131,6 @@ describe("serve", () => {
                 headers: {
                   "content-type": "application/json",
                   "upstash-forward-upstash-workflow-sdk-version": "1",
-                  "upstash-feature-set": "WF_NoDelete",
                   "upstash-retries": "3",
                   "upstash-method": "POST",
                   "upstash-workflow-runid": workflowRunId,
@@ -158,7 +157,6 @@ describe("serve", () => {
                 headers: {
                   "content-type": "application/json",
                   "upstash-forward-upstash-workflow-sdk-version": "1",
-                  "upstash-feature-set": "WF_NoDelete",
                   "upstash-method": "POST",
                   "upstash-retries": "3",
                   "upstash-workflow-runid": workflowRunId,
@@ -331,7 +329,6 @@ describe("serve", () => {
               destination: WORKFLOW_ENDPOINT,
               headers: {
                 "content-type": "application/json",
-                "upstash-feature-set": "WF_NoDelete",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",
                 "upstash-retries": "3",
@@ -377,7 +374,6 @@ describe("serve", () => {
               headers: {
                 "content-type": "application/json",
                 "upstash-delay": "1s",
-                "upstash-feature-set": "WF_NoDelete",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",
                 "upstash-retries": "3",
@@ -422,7 +418,6 @@ describe("serve", () => {
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",
                 "upstash-retries": "3",
-                "upstash-feature-set": "WF_NoDelete",
                 "upstash-workflow-init": "false",
                 "upstash-workflow-runid": "wfr-bar",
                 "upstash-workflow-url": WORKFLOW_ENDPOINT,
@@ -472,7 +467,6 @@ describe("serve", () => {
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",
                 "upstash-retries": "3",
-                "upstash-feature-set": "WF_NoDelete",
                 "upstash-workflow-init": "false",
                 "upstash-workflow-runid": "wfr-bar",
                 "upstash-workflow-url": WORKFLOW_ENDPOINT,

--- a/src/workflow-requests.test.ts
+++ b/src/workflow-requests.test.ts
@@ -342,7 +342,6 @@ describe("Workflow Requests", () => {
     test("should create headers without step passed", () => {
       const { headers, timeoutHeaders } = getHeaders("true", workflowRunId, WORKFLOW_ENDPOINT);
       expect(headers).toEqual({
-        [WORKFLOW_FEATURE_HEADER]: "WF_NoDelete",
         [WORKFLOW_INIT_HEADER]: "true",
         [WORKFLOW_ID_HEADER]: workflowRunId,
         [WORKFLOW_URL_HEADER]: WORKFLOW_ENDPOINT,
@@ -369,7 +368,6 @@ describe("Workflow Requests", () => {
         }
       );
       expect(headers).toEqual({
-        [WORKFLOW_FEATURE_HEADER]: "WF_NoDelete",
         [WORKFLOW_INIT_HEADER]: "false",
         [WORKFLOW_ID_HEADER]: workflowRunId,
         [WORKFLOW_URL_HEADER]: WORKFLOW_ENDPOINT,
@@ -410,7 +408,6 @@ describe("Workflow Requests", () => {
         [WORKFLOW_INIT_HEADER]: "false",
         [WORKFLOW_ID_HEADER]: workflowRunId,
         [WORKFLOW_URL_HEADER]: WORKFLOW_ENDPOINT,
-        [`Upstash-Forward-${WORKFLOW_PROTOCOL_VERSION_HEADER}`]: WORKFLOW_PROTOCOL_VERSION,
         "Upstash-Retries": "0",
         "Upstash-Callback": WORKFLOW_ENDPOINT,
         "Upstash-Callback-Forward-Upstash-Workflow-Callback": "true",
@@ -440,7 +437,6 @@ describe("Workflow Requests", () => {
         failureUrl
       );
       expect(headers).toEqual({
-        [WORKFLOW_FEATURE_HEADER]: "WF_NoDelete",
         [WORKFLOW_INIT_HEADER]: "true",
         [WORKFLOW_ID_HEADER]: workflowRunId,
         [WORKFLOW_URL_HEADER]: WORKFLOW_ENDPOINT,
@@ -467,7 +463,6 @@ describe("Workflow Requests", () => {
         }
       );
       expect(headers).toEqual({
-        [WORKFLOW_FEATURE_HEADER]: "WF_NoDelete",
         "Upstash-Workflow-Init": "false",
         "Upstash-Workflow-RunId": workflowRunId,
         "Upstash-Workflow-Url": WORKFLOW_ENDPOINT,
@@ -475,7 +470,6 @@ describe("Workflow Requests", () => {
         "Upstash-Workflow-CallType": "step",
       });
       expect(timeoutHeaders).toEqual({
-        [WORKFLOW_FEATURE_HEADER]: ["WF_NoDelete"],
         "Upstash-Workflow-Init": ["false"],
         "Upstash-Workflow-RunId": [workflowRunId],
         "Upstash-Workflow-Url": [WORKFLOW_ENDPOINT],

--- a/src/workflow-requests.ts
+++ b/src/workflow-requests.ts
@@ -287,9 +287,11 @@ export const getHeaders = (
     [WORKFLOW_INIT_HEADER]: initHeaderValue,
     [WORKFLOW_ID_HEADER]: workflowRunId,
     [WORKFLOW_URL_HEADER]: workflowUrl,
-    [WORKFLOW_FEATURE_HEADER]: "WF_NoDelete",
-    [`Upstash-Forward-${WORKFLOW_PROTOCOL_VERSION_HEADER}`]: WORKFLOW_PROTOCOL_VERSION,
   };
+
+  if (!step?.callUrl) {
+    baseHeaders[`Upstash-Forward-${WORKFLOW_PROTOCOL_VERSION_HEADER}`] = WORKFLOW_PROTOCOL_VERSION;
+  }
 
   if (failureUrl) {
     if (!step?.callUrl) {
@@ -302,6 +304,7 @@ export const getHeaders = (
   // for call url, retry is 0
   if (step?.callUrl) {
     baseHeaders["Upstash-Retries"] = "0";
+    baseHeaders[WORKFLOW_FEATURE_HEADER] = "WF_NoDelete";
 
     // if some retries is set, use it in callback and failure callback
     if (retries) {


### PR DESCRIPTION
feature header was supposed to only be sent in context.call instead of all requests. this is fixed

also, we don't forward the protocol header in the context.call request. this way, the request QStash makes doesn't have protocol header. so you can call another workflow endpoint.

merge after #5