### PR TITLE
String Duration Support for context.sleep and context.waitForEvent timeout

### DIFF
--- a/src/context/auto-executor.test.ts
+++ b/src/context/auto-executor.test.ts
@@ -192,8 +192,10 @@ describe("auto-executor", () => {
         execute: () => {
           expect(context.executor.getParallelCallState(2, 1)).toBe("first");
           const throws = Promise.all([
-            context.sleep("sleep for some time", 123),
+            context.sleep("sleep for 123s", 123),
+            context.sleep("sleep for 10m", "10m"),
             context.sleepUntil("sleep until next day", 123_123),
+            context.waitForEvent("waitEvent", "my-event", "5m"),
           ]);
           expect(throws).rejects.toThrowError(QStashWorkflowAbort);
         },
@@ -207,7 +209,7 @@ describe("auto-executor", () => {
           token,
           body: [
             {
-              body: '{"stepId":0,"stepName":"sleep for some time","stepType":"SleepFor","sleepFor":123,"concurrent":2,"targetStep":1}',
+              body: '{"stepId":0,"stepName":"sleep for 123s","stepType":"SleepFor","sleepFor":123,"concurrent":4,"targetStep":1}',
               destination: WORKFLOW_ENDPOINT,
               headers: {
                 "content-type": "application/json",
@@ -221,7 +223,21 @@ describe("auto-executor", () => {
               },
             },
             {
-              body: '{"stepId":0,"stepName":"sleep until next day","stepType":"SleepUntil","sleepUntil":123123,"concurrent":2,"targetStep":2}',
+              body: '{"stepId":0,"stepName":"sleep for 10m","stepType":"SleepFor","sleepFor":"10m","concurrent":4,"targetStep":2}',
+              destination: WORKFLOW_ENDPOINT,
+              headers: {
+                "content-type": "application/json",
+                "upstash-delay": "10m",
+                "upstash-forward-upstash-workflow-sdk-version": "1",
+                "upstash-method": "POST",
+                "upstash-retries": "3",
+                "upstash-workflow-runid": workflowRunId,
+                "upstash-workflow-init": "false",
+                "upstash-workflow-url": WORKFLOW_ENDPOINT,
+              },
+            },
+            {
+              body: '{"stepId":0,"stepName":"sleep until next day","stepType":"SleepUntil","sleepUntil":123123,"concurrent":4,"targetStep":3}',
               destination: WORKFLOW_ENDPOINT,
               headers: {
                 "content-type": "application/json",
@@ -229,6 +245,20 @@ describe("auto-executor", () => {
                 "upstash-method": "POST",
                 "upstash-retries": "3",
                 "upstash-not-before": "123123",
+                "upstash-workflow-runid": workflowRunId,
+                "upstash-workflow-init": "false",
+                "upstash-workflow-url": WORKFLOW_ENDPOINT,
+              },
+            },
+            {
+              body: '{"stepId":0,"stepName":"waitEvent","stepType":"Wait","waitEventId":"my-event","timeout":"5m","concurrent":4,"targetStep":4}',
+              destination: WORKFLOW_ENDPOINT,
+              headers: {
+                "content-type": "application/json",
+                "upstash-forward-upstash-workflow-sdk-version": "1",
+                "upstash-method": "POST",
+                "upstash-retries": "3",
+                "upstash-workflow-calltype": "step",
                 "upstash-workflow-runid": workflowRunId,
                 "upstash-workflow-init": "false",
                 "upstash-workflow-url": WORKFLOW_ENDPOINT,
@@ -242,11 +272,16 @@ describe("auto-executor", () => {
 
       expect(spyRunParallel).toHaveBeenCalledTimes(1);
       const lazySteps = spyRunParallel.mock.calls[0][0];
-      expect(lazySteps.length).toBe(2);
+      expect(lazySteps.length).toBe(4);
       expect(lazySteps[0].stepType).toBe("SleepFor");
-      expect(lazySteps[1].stepType).toBe("SleepUntil");
-      expect(lazySteps[0].stepName).toBe("sleep for some time");
-      expect(lazySteps[1].stepName).toBe("sleep until next day");
+      expect(lazySteps[1].stepType).toBe("SleepFor");
+      expect(lazySteps[2].stepType).toBe("SleepUntil");
+      expect(lazySteps[3].stepType).toBe("Wait");
+
+      expect(lazySteps[0].stepName).toBe("sleep for 123s");
+      expect(lazySteps[1].stepName).toBe("sleep for 10m");
+      expect(lazySteps[2].stepName).toBe("sleep until next day");
+      expect(lazySteps[3].stepName).toBe("waitEvent");
     });
 
     test("should send plan steps in second encounter: should run the first parallel step", async () => {

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -13,7 +13,7 @@ import {
 import type { HTTPMethods } from "@upstash/qstash";
 import type { WorkflowLogger } from "../logger";
 import { DEFAULT_RETRIES } from "../constants";
-import { Duration } from "./types";
+import type { Duration } from "../types";
 
 /**
  * Upstash Workflow context

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -364,7 +364,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
   public async waitForEvent(
     stepName: string,
     eventId: string,
-    timeout: number
+    timeout: number | Duration
   ): Promise<WaitStepResponse> {
     const result = await this.addStep(
       new LazyWaitForEventStep(

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -13,6 +13,7 @@ import {
 import type { HTTPMethods } from "@upstash/qstash";
 import type { WorkflowLogger } from "../logger";
 import { DEFAULT_RETRIES } from "../constants";
+import { Duration } from "./types";
 
 /**
  * Upstash Workflow context
@@ -228,7 +229,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
    * @param duration sleep duration in seconds
    * @returns undefined
    */
-  public async sleep(stepName: string, duration: number): Promise<void> {
+  public async sleep(stepName: string, duration: number | Duration): Promise<void> {
     await this.addStep(new LazySleepStep(stepName, duration));
   }
 

--- a/src/context/steps.test.ts
+++ b/src/context/steps.test.ts
@@ -52,9 +52,12 @@ describe("test steps", () => {
     });
   });
 
-  describe("sleep step", () => {
+  describe.only("sleep step", () => {
     const sleepAmount = 123_123;
     const step = new LazySleepStep(stepName, sleepAmount);
+
+    const sleepWithDuration = "90s";
+    const stepWithDuration = new LazySleepStep(stepName, sleepWithDuration);
 
     test("should set correct fields", () => {
       expect(step.stepName).toBe(stepName);
@@ -77,6 +80,27 @@ describe("test steps", () => {
         stepName,
         stepType: "SleepFor",
         sleepFor: sleepAmount, // adding sleepFor
+        concurrent: 6,
+      });
+    });
+
+    test("should create plan step with duration", () => {
+      expect(stepWithDuration.getPlanStep(concurrent, targetStep)).toEqual({
+        stepId: 0,
+        stepName,
+        stepType: "SleepFor",
+        sleepFor: sleepWithDuration,
+        concurrent,
+        targetStep,
+      });
+    })
+
+    test("should create result step", async () => {
+      expect(await stepWithDuration.getResultStep(6, stepId)).toEqual({
+        stepId,
+        stepName,
+        stepType: "SleepFor",
+        sleepFor: sleepWithDuration,
         concurrent: 6,
       });
     });

--- a/src/context/steps.test.ts
+++ b/src/context/steps.test.ts
@@ -52,7 +52,7 @@ describe("test steps", () => {
     });
   });
 
-  describe.only("sleep step", () => {
+  describe("sleep step", () => {
     const sleepAmount = 123_123;
     const step = new LazySleepStep(stepName, sleepAmount);
 

--- a/src/context/steps.ts
+++ b/src/context/steps.ts
@@ -1,7 +1,7 @@
 import type { Client, HTTPMethods } from "@upstash/qstash";
 import type { NotifyStepResponse, Step, StepFunction, StepType, WaitStepResponse } from "../types";
 import { makeNotifyRequest } from "../client/utils";
-import { Duration } from "./types";
+import type { Duration } from "../types";
 
 /**
  * Base class outlining steps. Basically, each step kind (run/sleep/sleepUntil)

--- a/src/context/steps.ts
+++ b/src/context/steps.ts
@@ -1,6 +1,7 @@
 import type { Client, HTTPMethods } from "@upstash/qstash";
 import type { NotifyStepResponse, Step, StepFunction, StepType, WaitStepResponse } from "../types";
 import { makeNotifyRequest } from "../client/utils";
+import { Duration } from "./types";
 
 /**
  * Base class outlining steps. Basically, each step kind (run/sleep/sleepUntil)
@@ -78,10 +79,10 @@ export class LazyFunctionStep<TResult = unknown> extends BaseLazyStep<TResult> {
  * Lazy step definition for `context.sleep` case
  */
 export class LazySleepStep extends BaseLazyStep {
-  private readonly sleep: number;
+  private readonly sleep: number | Duration;
   stepType: StepType = "SleepFor";
 
-  constructor(stepName: string, sleep: number) {
+  constructor(stepName: string, sleep: number | Duration) {
     super(stepName);
     this.sleep = sleep;
   }

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -1,4 +1,0 @@
-type Unit = "ms" | "s" | "m" | "h" | "d";
-
-export type Duration = `${number}${Unit}`;
-

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -1,0 +1,4 @@
+type Unit = "ms" | "s" | "m" | "h" | "d";
+
+export type Duration = `${number}${Unit}`;
+

--- a/src/serve/serve.test.ts
+++ b/src/serve/serve.test.ts
@@ -589,4 +589,67 @@ describe("serve", () => {
     });
     expect(receiver).toBeDefined();
   });
+
+  test("should send waitForEvent", async () => {
+    const request = getRequest(WORKFLOW_ENDPOINT, "wfr-bar", "my-payload", []);
+    const { handler: endpoint } = serve(async (context) => {
+      await context.waitForEvent("waiting step", "wait-event-id", "10d")
+    }, {
+      qstashClient,
+      receiver: undefined,
+    });
+    let called = false;
+    await mockQStashServer({
+      execute: async () => {
+        const result = await endpoint(request);
+        expect(result.status).toBe(200);
+        called = true;
+      },
+      responseFields: { body: { messageId: "some-message-id" }, status: 200 },
+      receivesRequest: {
+        method: "POST",
+        url: `${MOCK_QSTASH_SERVER_URL}/v2/wait/wait-event-id`,
+        token,
+        body: {
+          step: {
+            concurrent: 1,
+            stepId: 1,
+            stepName: "waiting step",
+            stepType: "Wait",
+          },
+          timeout: "10d",
+          timeoutHeaders: {
+            "Content-Type": [
+              "application/json"
+            ],
+            "Upstash-Forward-Upstash-Workflow-Sdk-Version": [
+              "1"
+            ],
+            "Upstash-Retries": [
+              "3"
+            ],
+            "Upstash-Workflow-CallType": [
+              "step"
+            ],
+            "Upstash-Workflow-Init": [
+              "false"
+            ],
+            "Upstash-Workflow-RunId": [
+              "wfr-bar"
+            ],
+            "Upstash-Workflow-Runid": [
+              "wfr-bar"
+            ],
+            "Upstash-Workflow-Url": [
+              WORKFLOW_ENDPOINT
+            ],
+          },
+          timeoutUrl: WORKFLOW_ENDPOINT,
+          url: WORKFLOW_ENDPOINT,
+        }
+      },
+    });
+    expect(called).toBeTrue();
+
+  })
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,6 @@ import type { Client } from "@upstash/qstash";
 import type { HTTPMethods } from "@upstash/qstash";
 import type { WorkflowContext } from "./context";
 import type { WorkflowLogger } from "./logger";
-import { Duration } from "./context/types";
 
 /**
  * Interface for Client with required methods
@@ -292,3 +291,7 @@ export type CallResponse = {
   body: unknown;
   header: Record<string, string[]>;
 };
+
+type Unit = "ms" | "s" | "m" | "h" | "d";
+
+export type Duration = `${number}${Unit}`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import type { Client } from "@upstash/qstash";
 import type { HTTPMethods } from "@upstash/qstash";
 import type { WorkflowContext } from "./context";
 import type { WorkflowLogger } from "./logger";
+import { Duration } from "./context/types";
 
 /**
  * Interface for Client with required methods
@@ -84,7 +85,7 @@ export type Step<TResult = unknown, TBody = unknown> = {
   /**
    * sleep duration in seconds. Set when context.sleep is used.
    */
-  sleepFor?: number;
+  sleepFor?: number | Duration;
   /**
    * unix timestamp (in seconds) to wait until. Set when context.sleepUntil is used.
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -292,6 +292,5 @@ export type CallResponse = {
   header: Record<string, string[]>;
 };
 
-type Unit = "ms" | "s" | "m" | "h" | "d";
 
-export type Duration = `${number}${Unit}`;
+export type Duration = `${bigint}s` | `${bigint}m` | `${bigint}h` | `${bigint}d`


### PR DESCRIPTION
Right now, the only way to pass durations is by number as below.
```javascript
await context.sleep("wait-until-welcome-email", 60 * 60 * 24);
```

With this PR, we're introducing a `Duration` type, where interface allows to pass durations as `1d`, `90m` etc. as below

```javascript
await context.sleep("wait-until-welcome-email", "90m");
```