### PR TITLE
Sort steps with .sort instead of .toSorted

### DIFF
--- a/src/context/auto-executor.ts
+++ b/src/context/auto-executor.ts
@@ -529,5 +529,5 @@ const validateParallelSteps = (lazySteps: BaseLazyStep[], stepsFromRequest: Step
  */
 const sortSteps = (steps: Step[]): Step[] => {
   const getStepId = (step: Step) => step.targetStep || step.stepId;
-  return steps.toSorted((step, stepOther) => getStepId(step) - getStepId(stepOther));
+  return [...steps].sort((step, stepOther) => getStepId(step) - getStepId(stepOther));
 };


### PR DESCRIPTION
Equivalent of https://github.com/upstash/qstash-js/pull/210 for workflow-js

This will allow running workflow with Node versions before Node v20.