### PR TITLE
Add context.call retry option

### DIFF
--- a/platforms/express.ts
+++ b/platforms/express.ts
@@ -1,8 +1,11 @@
-
 import type { WorkflowServeOptions, RouteFunction } from "../src";
 import { serve as serveBase } from "../src";
-import { Request as ExpressRequest, Response as ExpressResponse, Router, RequestHandler } from "express";
-
+import {
+  Request as ExpressRequest,
+  Response as ExpressResponse,
+  Router,
+  RequestHandler,
+} from "express";
 
 export function serve<TInitialPayload = unknown>(
   routeFunction: RouteFunction<TInitialPayload>,
@@ -11,7 +14,6 @@ export function serve<TInitialPayload = unknown>(
   const router = Router();
 
   const handler: RequestHandler = async (request_: ExpressRequest, res: ExpressResponse) => {
-
     // only allow POST requests
     if (request_.method.toUpperCase() !== "POST") {
       res.status(405).json("Only POST requests are allowed in workflows");
@@ -19,20 +21,20 @@ export function serve<TInitialPayload = unknown>(
     }
 
     // only allow application/json content type
-    if (request_.headers['content-type'] !== 'application/json') {
+    if (request_.headers["content-type"] !== "application/json") {
       res.status(400).json("Only application/json content type is allowed in express workflows");
       return;
     }
 
     // create Request
     const protocol = request_.protocol;
-    const host = request_.get('host') || 'localhost';
+    const host = request_.get("host") || "localhost";
     const url = `${protocol}://${host}${request_.originalUrl}`;
 
     const webRequest = new Request(url, {
       method: request_.method,
       headers: new Headers(request_.headers as Record<string, string>),
-      body: JSON.stringify(request_.body)
+      body: JSON.stringify(request_.body),
     });
 
     // create handler
@@ -44,10 +46,9 @@ export function serve<TInitialPayload = unknown>(
     const response = await serveHandler(webRequest);
 
     res.status(response.status).json(await response.json());
-
   };
 
-  router.all('*', handler);
+  router.all("*", handler);
 
   return router;
 }

--- a/src/context/auto-executor.ts
+++ b/src/context/auto-executor.ts
@@ -1,7 +1,7 @@
 import { QStashWorkflowAbort, QStashWorkflowError } from "../error";
 import type { WorkflowContext } from "./context";
 import type { StepFunction, ParallelCallState, Step, WaitRequest } from "../types";
-import { type BaseLazyStep } from "./steps";
+import { LazyCallStep, type BaseLazyStep } from "./steps";
 import { getHeaders } from "../workflow-requests";
 import type { WorkflowLogger } from "../logger";
 import { NO_CONCURRENCY } from "../constants";
@@ -131,7 +131,7 @@ export class AutoExecutor {
       step: resultStep,
       stepCount: this.stepCount,
     });
-    await this.submitStepsToQStash([resultStep]);
+    await this.submitStepsToQStash([resultStep], [lazyStep]);
 
     return resultStep.out as TResult;
   }
@@ -182,7 +182,7 @@ export class AutoExecutor {
         const planSteps = parallelSteps.map((parallelStep, index) =>
           parallelStep.getPlanStep(parallelSteps.length, initialStepCount + index)
         );
-        await this.submitStepsToQStash(planSteps);
+        await this.submitStepsToQStash(planSteps, parallelSteps);
         break;
       }
       case "partial": {
@@ -211,11 +211,12 @@ export class AutoExecutor {
         // sleep/sleepUntil. It's only possible here:
         validateStep(parallelSteps[stepIndex], planStep);
         try {
-          const resultStep = await parallelSteps[stepIndex].getResultStep(
+          const parallelStep = parallelSteps[stepIndex];
+          const resultStep = await parallelStep.getResultStep(
             parallelSteps.length,
             planStep.targetStep
           );
-          await this.submitStepsToQStash([resultStep]);
+          await this.submitStepsToQStash([resultStep], [parallelStep]);
         } catch (error) {
           if (error instanceof QStashWorkflowAbort) {
             throw error;
@@ -309,7 +310,7 @@ export class AutoExecutor {
    *
    * @param steps steps to send
    */
-  private async submitStepsToQStash(steps: Step[]) {
+  private async submitStepsToQStash(steps: Step[], lazySteps: BaseLazyStep[]) {
     // if there are no steps, something went wrong. Raise exception
     if (steps.length === 0) {
       throw new QStashWorkflowError(
@@ -363,7 +364,8 @@ export class AutoExecutor {
     }
 
     const result = await this.context.qstashClient.batchJSON(
-      steps.map((singleStep) => {
+      steps.map((singleStep, index) => {
+        const lazyStep = lazySteps[index];
         const { headers } = getHeaders(
           "false",
           this.context.workflowRunId,
@@ -371,7 +373,8 @@ export class AutoExecutor {
           this.context.headers,
           singleStep,
           this.context.failureUrl,
-          this.context.retries
+          this.context.retries,
+          lazyStep instanceof LazyCallStep ? lazyStep.retries : undefined
         );
 
         // if the step is a single step execution or a plan step, we can add sleep headers

--- a/src/context/context.test.ts
+++ b/src/context/context.test.ts
@@ -262,4 +262,134 @@ describe("context tests", () => {
       });
     });
   });
+
+  describe("steps", () => {
+    const url = "https://some-website.com";
+    const body = "request-body";
+    test("should send correct headers for context.call", async () => {
+      const retries = 10;
+      const context = new WorkflowContext({
+        qstashClient,
+        initialPayload: "my-payload",
+        steps: [],
+        url: WORKFLOW_ENDPOINT,
+        headers: new Headers() as Headers,
+        workflowRunId: "wfr-id",
+      });
+      await mockQStashServer({
+        execute: () => {
+          const throws = () =>
+            context.call("my-step", {
+              url,
+              body,
+              headers: { "my-header": "my-value" },
+              method: "PATCH",
+              retries: retries,
+            });
+          expect(throws).toThrowError("Aborting workflow after executing step 'my-step'.");
+        },
+        responseFields: {
+          status: 200,
+          body: "msgId",
+        },
+        receivesRequest: {
+          method: "POST",
+          url: `${MOCK_QSTASH_SERVER_URL}/v2/batch`,
+          token,
+          body: [
+            {
+              body: '"request-body"',
+              destination: url,
+              headers: {
+                "content-type": "application/json",
+                "upstash-callback": WORKFLOW_ENDPOINT,
+                "upstash-callback-forward-upstash-workflow-callback": "true",
+                "upstash-callback-forward-upstash-workflow-concurrent": "1",
+                "upstash-callback-forward-upstash-workflow-contenttype": "application/json",
+                "upstash-callback-forward-upstash-workflow-stepid": "1",
+                "upstash-callback-forward-upstash-workflow-stepname": "my-step",
+                "upstash-callback-forward-upstash-workflow-steptype": "Call",
+                "upstash-callback-retries": "3",
+                "upstash-callback-workflow-calltype": "fromCallback",
+                "upstash-callback-workflow-init": "false",
+                "upstash-callback-workflow-runid": "wfr-id",
+                "upstash-callback-workflow-url": WORKFLOW_ENDPOINT,
+                "upstash-failure-callback-retries": "3",
+                "upstash-feature-set": "WF_NoDelete",
+                "upstash-forward-my-header": "my-value",
+                "upstash-method": "PATCH",
+                "upstash-retries": retries.toString(),
+                "upstash-workflow-calltype": "toCallback",
+                "upstash-workflow-init": "false",
+                "upstash-workflow-runid": "wfr-id",
+                "upstash-workflow-url": WORKFLOW_ENDPOINT,
+              },
+            },
+          ],
+        },
+      });
+    });
+
+    test("should send correct headers for context.call with default retry", async () => {
+      const context = new WorkflowContext({
+        qstashClient,
+        initialPayload: "my-payload",
+        steps: [],
+        url: WORKFLOW_ENDPOINT,
+        headers: new Headers() as Headers,
+        workflowRunId: "wfr-id",
+      });
+      await mockQStashServer({
+        execute: () => {
+          const throws = () =>
+            context.call("my-step", {
+              url,
+              body,
+              headers: { "my-header": "my-value" },
+              method: "PATCH",
+            });
+          expect(throws).toThrowError("Aborting workflow after executing step 'my-step'.");
+        },
+        responseFields: {
+          status: 200,
+          body: "msgId",
+        },
+        receivesRequest: {
+          method: "POST",
+          url: `${MOCK_QSTASH_SERVER_URL}/v2/batch`,
+          token,
+          body: [
+            {
+              body: '"request-body"',
+              destination: url,
+              headers: {
+                "content-type": "application/json",
+                "upstash-callback": WORKFLOW_ENDPOINT,
+                "upstash-callback-forward-upstash-workflow-callback": "true",
+                "upstash-callback-forward-upstash-workflow-concurrent": "1",
+                "upstash-callback-forward-upstash-workflow-contenttype": "application/json",
+                "upstash-callback-forward-upstash-workflow-stepid": "1",
+                "upstash-callback-forward-upstash-workflow-stepname": "my-step",
+                "upstash-callback-forward-upstash-workflow-steptype": "Call",
+                "upstash-callback-retries": "3",
+                "upstash-callback-workflow-calltype": "fromCallback",
+                "upstash-callback-workflow-init": "false",
+                "upstash-callback-workflow-runid": "wfr-id",
+                "upstash-callback-workflow-url": WORKFLOW_ENDPOINT,
+                "upstash-failure-callback-retries": "3",
+                "upstash-feature-set": "WF_NoDelete",
+                "upstash-forward-my-header": "my-value",
+                "upstash-method": "PATCH",
+                "upstash-retries": "0",
+                "upstash-workflow-calltype": "toCallback",
+                "upstash-workflow-init": "false",
+                "upstash-workflow-runid": "wfr-id",
+                "upstash-workflow-url": WORKFLOW_ENDPOINT,
+              },
+            },
+          ],
+        },
+      });
+    });
+  });
 });

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -259,11 +259,13 @@ export class WorkflowContext<TInitialPayload = unknown> {
    * network call without consuming any runtime.
    *
    * ```ts
-   * const postResult = await context.call<string>(
+   * const { status, body } = await context.call<string>(
    *   "post call step",
-   *   `https://www.some-endpoint.com/api`,
-   *   "POST",
-   *   "my-payload"
+   *   {
+   *     url: `https://www.some-endpoint.com/api`,
+   *     method: "POST",
+   *     body: "my-payload"
+   *   }
    * );
    * ```
    *
@@ -273,28 +275,30 @@ export class WorkflowContext<TInitialPayload = unknown> {
    *
    * @param stepName
    * @param url url to call
-   * @param method call method
+   * @param method call method. "GET" by default.
    * @param body call body
    * @param headers call headers
+   * @param retries number of call retries. 0 by default
    * @returns call result as {
    *     status: number;
    *     body: unknown;
    *     header: Record<string, string[]>
    *   }
    */
-  public async call(
+  public async call<TResult = unknown>(
     stepName: string,
     settings: {
       url: string;
       method?: HTTPMethods;
       body?: unknown;
       headers?: Record<string, string>;
+      retries?: number;
     }
-  ): Promise<CallResponse> {
-    const { url, method = "GET", body, headers = {} } = settings;
+  ): Promise<CallResponse<TResult>> {
+    const { url, method = "GET", body, headers = {}, retries = 0 } = settings;
 
     const result = await this.addStep(
-      new LazyCallStep<CallResponse | string>(stepName, url, method, body, headers ?? {})
+      new LazyCallStep<CallResponse<string> | string>(stepName, url, method, body, headers, retries)
     );
 
     // <for backwards compatibity>
@@ -313,7 +317,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
         return {
           status: 200,
           header: {},
-          body: result,
+          body: result as TResult,
         };
       }
     }
@@ -325,7 +329,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
         body: JSON.parse(result.body as string),
       };
     } catch {
-      return result;
+      return result as CallResponse<TResult>;
     }
   }
 

--- a/src/context/steps.test.ts
+++ b/src/context/steps.test.ts
@@ -93,7 +93,7 @@ describe("test steps", () => {
         concurrent,
         targetStep,
       });
-    })
+    });
 
     test("should create result step", async () => {
       expect(await stepWithDuration.getResultStep(6, stepId)).toEqual({
@@ -145,7 +145,7 @@ describe("test steps", () => {
     const callHeaders = {
       "my-header": headerValue,
     };
-    const step = new LazyCallStep(stepName, callUrl, callMethod, callBody, callHeaders);
+    const step = new LazyCallStep(stepName, callUrl, callMethod, callBody, callHeaders, 14);
 
     test("should set correct fields", () => {
       expect(step.stepName).toBe(stepName);

--- a/src/context/steps.ts
+++ b/src/context/steps.ts
@@ -149,19 +149,22 @@ export class LazyCallStep<TResult = unknown, TBody = unknown> extends BaseLazySt
   private readonly body: TBody;
   private readonly headers: Record<string, string>;
   stepType: StepType = "Call";
+  public readonly retries: number;
 
   constructor(
     stepName: string,
     url: string,
     method: HTTPMethods,
     body: TBody,
-    headers: Record<string, string>
+    headers: Record<string, string>,
+    retries: number
   ) {
     super(stepName);
     this.url = url;
     this.method = method;
     this.body = body;
     this.headers = headers;
+    this.retries = retries;
   }
 
   public getPlanStep(concurrent: number, targetStep: number): Step<undefined> {

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -396,7 +396,7 @@ describe.skip("live serve tests", () => {
             return;
           }
 
-          const { body: postResult } = await context.call("post call", {
+          const { body: postResult } = await context.call<string>("post call", {
             url: LOCAL_THIRD_PARTY_URL,
             method: "POST",
             body: "post-payload",
@@ -408,7 +408,7 @@ describe.skip("live serve tests", () => {
 
           await context.sleep("sleep 1", 2);
 
-          const { body: getResult } = await context.call("get call", {
+          const { body: getResult } = await context.call<string>("get call", {
             url: LOCAL_THIRD_PARTY_URL,
             headers: getHeader,
           });
@@ -516,7 +516,7 @@ describe.skip("live serve tests", () => {
         finishState,
         routeFunction: async (context) => {
           const input = context.requestPayload;
-          const { status, body, header } = await context.call("failing call", {
+          const { status, body, header } = await context.call<string>("failing call", {
             url: LOCAL_THIRD_PARTY_URL,
             body: input,
             method: "POST",

--- a/src/serve/serve.test.ts
+++ b/src/serve/serve.test.ts
@@ -592,12 +592,15 @@ describe("serve", () => {
 
   test("should send waitForEvent", async () => {
     const request = getRequest(WORKFLOW_ENDPOINT, "wfr-bar", "my-payload", []);
-    const { handler: endpoint } = serve(async (context) => {
-      await context.waitForEvent("waiting step", "wait-event-id", "10d")
-    }, {
-      qstashClient,
-      receiver: undefined,
-    });
+    const { handler: endpoint } = serve(
+      async (context) => {
+        await context.waitForEvent("waiting step", "wait-event-id", "10d");
+      },
+      {
+        qstashClient,
+        receiver: undefined,
+      }
+    );
     let called = false;
     await mockQStashServer({
       execute: async () => {
@@ -619,37 +622,20 @@ describe("serve", () => {
           },
           timeout: "10d",
           timeoutHeaders: {
-            "Content-Type": [
-              "application/json"
-            ],
-            "Upstash-Forward-Upstash-Workflow-Sdk-Version": [
-              "1"
-            ],
-            "Upstash-Retries": [
-              "3"
-            ],
-            "Upstash-Workflow-CallType": [
-              "step"
-            ],
-            "Upstash-Workflow-Init": [
-              "false"
-            ],
-            "Upstash-Workflow-RunId": [
-              "wfr-bar"
-            ],
-            "Upstash-Workflow-Runid": [
-              "wfr-bar"
-            ],
-            "Upstash-Workflow-Url": [
-              WORKFLOW_ENDPOINT
-            ],
+            "Content-Type": ["application/json"],
+            "Upstash-Forward-Upstash-Workflow-Sdk-Version": ["1"],
+            "Upstash-Retries": ["3"],
+            "Upstash-Workflow-CallType": ["step"],
+            "Upstash-Workflow-Init": ["false"],
+            "Upstash-Workflow-RunId": ["wfr-bar"],
+            "Upstash-Workflow-Runid": ["wfr-bar"],
+            "Upstash-Workflow-Url": [WORKFLOW_ENDPOINT],
           },
           timeoutUrl: WORKFLOW_ENDPOINT,
           url: WORKFLOW_ENDPOINT,
-        }
+        },
       },
     });
     expect(called).toBeTrue();
-
-  })
+  });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -286,11 +286,10 @@ export type NotifyStepResponse = {
   notifyResponse: NotifyResponse[];
 };
 
-export type CallResponse = {
+export type CallResponse<TResult = unknown> = {
   status: number;
-  body: unknown;
+  body: TResult;
   header: Record<string, string[]>;
 };
 
-
-export type Duration = `${bigint}s` | `${bigint}m` | `${bigint}h` | `${bigint}d`
+export type Duration = `${bigint}s` | `${bigint}m` | `${bigint}h` | `${bigint}d`;

--- a/src/workflow-parser.ts
+++ b/src/workflow-parser.ts
@@ -190,7 +190,7 @@ export const validateRequest = (
   if (!isFirstInvocation && versionHeader !== WORKFLOW_PROTOCOL_VERSION) {
     throw new QStashWorkflowError(
       `Incompatible workflow sdk protocol version. Expected ${WORKFLOW_PROTOCOL_VERSION},` +
-      ` got ${versionHeader} from the request.`
+        ` got ${versionHeader} from the request.`
     );
   }
 
@@ -278,8 +278,8 @@ export const handleFailure = async <TInitialPayload>(
     return err(
       new QStashWorkflowError(
         "Workflow endpoint is called to handle a failure," +
-        " but a failureFunction is not provided in serve options." +
-        " Either provide a failureUrl or a failureFunction."
+          " but a failureFunction is not provided in serve options." +
+          " Either provide a failureUrl or a failureFunction."
       )
     );
   }

--- a/src/workflow-requests.ts
+++ b/src/workflow-requests.ts
@@ -281,7 +281,8 @@ export const getHeaders = (
   userHeaders?: Headers,
   step?: Step,
   failureUrl?: WorkflowServeOptions["failureUrl"],
-  retries?: number
+  retries?: number,
+  callRetries?: number
 ): HeadersResponse => {
   const baseHeaders: Record<string, string> = {
     [WORKFLOW_INIT_HEADER]: initHeaderValue,
@@ -303,7 +304,7 @@ export const getHeaders = (
   // if retries is set or if call url is passed, set a retry
   // for call url, retry is 0
   if (step?.callUrl) {
-    baseHeaders["Upstash-Retries"] = "0";
+    baseHeaders["Upstash-Retries"] = callRetries?.toString() ?? "0";
     baseHeaders[WORKFLOW_FEATURE_HEADER] = "WF_NoDelete";
 
     // if some retries is set, use it in callback and failure callback


### PR DESCRIPTION
Adds `retries` parameter to `context.call` to make it possible to set the number of times the external call will retry.

```ts
await context.call("call", {
  url: ...,
  retries: 3
})
```

default value is 0 retry.

Also, added back the return type generic for context.call:

```ts
// body will be MyType
const { body } = await context.call<MyType>(...)
```