### PR TITLE
Refactor `failureFunction` args

### DIFF
--- a/examples/ci/app/test-routes/failureFunction-retry/route.ts
+++ b/examples/ci/app/test-routes/failureFunction-retry/route.ts
@@ -31,7 +31,7 @@ export const { POST, GET } = testServe(
     }, {
       baseUrl: BASE_URL,
       retries: 1,
-      failureFunction: async (context, failStatus, failResponse) => {
+      failureFunction: async ({ context, failStatus, failResponse }) => {
         expect(failStatus, 500);
         expect(failResponse, errorMessage);
         expect(context.headers.get("authentication")!, authHeaderValue);

--- a/examples/ci/app/test-routes/failureFunction/route.ts
+++ b/examples/ci/app/test-routes/failureFunction/route.ts
@@ -26,7 +26,7 @@ export const { POST, GET } = testServe(
     }, {
       baseUrl: BASE_URL,
       retries: 0,
-      failureFunction: async (context, failStatus, failResponse) => {
+      failureFunction: async ({ context, failStatus, failResponse }) => {
         expect(failStatus, 500);
         expect(failResponse, errorMessage);
         expect(context.headers.get("authentication")!, authHeaderValue);

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -480,7 +480,7 @@ describe.skip("live serve tests", () => {
           });
         },
         retries: 0,
-        failureFunction: (context, failStatus, failResponse, failHeaders) => {
+        failureFunction: ({ context, failStatus, failResponse, failHeaders }) => {
           expect(failStatus).toBe(500);
           expect(failResponse).toBe("my-custom-error");
           expect(context.headers.get("authentication")).toBe("Bearer secretPassword");
@@ -557,7 +557,7 @@ describe.skip("live serve tests", () => {
           });
         },
         retries: 1,
-        failureFunction: (context, failStatus, failResponse, failHeaders) => {
+        failureFunction: ({ context, failStatus, failResponse, failHeaders }) => {
           expect(failStatus).toBe(500);
           expect(failResponse).toBe("my-custom-error");
           expect(context.headers.get("authentication")).toBe("Bearer secretPassword");

--- a/src/serve/serve.test.ts
+++ b/src/serve/serve.test.ts
@@ -443,11 +443,7 @@ describe("serve", () => {
     test("should set failureUrl as context url if failureFunction is passed", async () => {
       const request = getRequest(WORKFLOW_ENDPOINT, "wfr-bar", "my-payload", []);
       let called = false;
-      const myFailureFunction: WorkflowServeOptions["failureFunction"] = async (
-        _status,
-        _header,
-        _body
-      ) => {
+      const myFailureFunction: WorkflowServeOptions["failureFunction"] = async () => {
         return;
       };
       const { handler: endpoint } = serve(routeFunction, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -183,14 +183,15 @@ export type WorkflowServeOptions<
    * @param failResponse error message
    * @returns void
    */
-  failureFunction?: (
-    failureData: {
-      context: Omit<WorkflowContext, "run" | "sleepUntil" | "sleep" | "call" | "waitForEvent" | "notify">
-      failStatus: number;
-      failResponse: string;
-      failHeader: Record<string, string[]>
-    }
-  ) => Promise<void> | void;
+  failureFunction?: (failureData: {
+    context: Omit<
+      WorkflowContext,
+      "run" | "sleepUntil" | "sleep" | "call" | "waitForEvent" | "notify"
+    >;
+    failStatus: number;
+    failResponse: string;
+    failHeaders: Record<string, string[]>;
+  }) => Promise<void> | void;
   /**
    * Base Url of the workflow endpoint
    *

--- a/src/workflow-parser.test.ts
+++ b/src/workflow-parser.test.ts
@@ -67,7 +67,7 @@ describe("Workflow Parser", () => {
       expect(throws).toThrow(
         new QStashWorkflowError(
           `Incompatible workflow sdk protocol version.` +
-          ` Expected ${WORKFLOW_PROTOCOL_VERSION}, got ${requestProtocol} from the request.`
+            ` Expected ${WORKFLOW_PROTOCOL_VERSION}, got ${requestProtocol} from the request.`
         )
       );
     });
@@ -639,11 +639,11 @@ describe("Workflow Parser", () => {
     };
     test("should return not-failure-callback when the header is not set", async () => {
       const request = new Request(WORKFLOW_ENDPOINT);
-      const failureFunction: WorkflowServeOptions["failureFunction"] = async (
-        { context,
-          failStatus,
-          failResponse }
-      ) => {
+      const failureFunction: WorkflowServeOptions["failureFunction"] = async ({
+        context,
+        failStatus,
+        failResponse,
+      }) => {
         return;
       };
 
@@ -676,8 +676,8 @@ describe("Workflow Parser", () => {
       expect(result.isErr() && result.error.name).toBe(QStashWorkflowError.name);
       expect(result.isErr() && result.error.message).toBe(
         "Workflow endpoint is called to handle a failure," +
-        " but a failureFunction is not provided in serve options." +
-        " Either provide a failureUrl or a failureFunction."
+          " but a failureFunction is not provided in serve options." +
+          " Either provide a failureUrl or a failureFunction."
       );
     });
 
@@ -688,9 +688,11 @@ describe("Workflow Parser", () => {
           [WORKFLOW_FAILURE_HEADER]: "true",
         },
       });
-      const failureFunction: WorkflowServeOptions["failureFunction"] = async (
-        { failHeader, failResponse, failStatus }
-      ) => {
+      const failureFunction: WorkflowServeOptions["failureFunction"] = async ({
+        failHeaders,
+        failResponse,
+        failStatus,
+      }) => {
         throw new Error("my-error");
       };
 
@@ -712,11 +714,11 @@ describe("Workflow Parser", () => {
           [WORKFLOW_FAILURE_HEADER]: "true",
         },
       });
-      const failureFunction: WorkflowServeOptions["failureFunction"] = async (
-        { context,
-          failStatus,
-          failResponse }
-      ) => {
+      const failureFunction: WorkflowServeOptions["failureFunction"] = async ({
+        context,
+        failStatus,
+        failResponse,
+      }) => {
         expect(failStatus).toBe(201);
         expect(failResponse).toBe(failMessage);
         expect(context.headers.get("authorization")).toBe(authorization);

--- a/src/workflow-parser.ts
+++ b/src/workflow-parser.ts
@@ -190,7 +190,7 @@ export const validateRequest = (
   if (!isFirstInvocation && versionHeader !== WORKFLOW_PROTOCOL_VERSION) {
     throw new QStashWorkflowError(
       `Incompatible workflow sdk protocol version. Expected ${WORKFLOW_PROTOCOL_VERSION},` +
-      ` got ${versionHeader} from the request.`
+        ` got ${versionHeader} from the request.`
     );
   }
 
@@ -278,8 +278,8 @@ export const handleFailure = async <TInitialPayload>(
     return err(
       new QStashWorkflowError(
         "Workflow endpoint is called to handle a failure," +
-        " but a failureFunction is not provided in serve options." +
-        " Either provide a failureUrl or a failureFunction."
+          " but a failureFunction is not provided in serve options." +
+          " Either provide a failureUrl or a failureFunction."
       )
     );
   }
@@ -321,7 +321,12 @@ export const handleFailure = async <TInitialPayload>(
       debug,
     });
 
-    await failureFunction({ context: workflowContext, failStatus: status, failResponse: errorPayload.message, failHeader: header });
+    await failureFunction({
+      context: workflowContext,
+      failStatus: status,
+      failResponse: errorPayload.message,
+      failHeaders: header,
+    });
   } catch (error) {
     return err(error as Error);
   }


### PR DESCRIPTION
Currently the failureFunction interface is as below. To recieve the `failHeaders`, you also need to pass the args before. With this PR, you can now destructure the args and use only what you need.
```typescript
export const { POST } = serve<string>(
  async (context) => { ... },
  {
    failureFunction: async (
      context,      // context during failure
      failStatus,   // failure status
      failResponse, // failure message
      failHeaders   // failure headers
    ) => {
      // handle the failure
    }
  }
);
```

This is now turned into 

```typescript
export const { POST } = serve<string>(async (context) => {
  ...
}, {
  failureFunction: async ({ context, failResponse }) => {
    //handle the failure
  },
})
```