### PR TITLE
Handle undefined body correctly in failureFunction

### DIFF
--- a/examples/ci/app/test-routes/failureFunction/route.ts
+++ b/examples/ci/app/test-routes/failureFunction/route.ts
@@ -9,7 +9,7 @@ const headerValue = `header-bar`
 const authHeaderValue = `Bearer super-secret-token`
 
 const errorMessage = `my-error`
-const payload = "my-payload"
+const payload = undefined
 
 
 export const { POST, GET } = testServe(
@@ -17,6 +17,7 @@ export const { POST, GET } = testServe(
     async (context) => {
       const input = context.requestPayload;
 
+      expect(typeof input, typeof payload);
       expect(input, payload);
       expect(context.headers.get(header)!, headerValue)
 
@@ -29,6 +30,8 @@ export const { POST, GET } = testServe(
       failureFunction: async ({ context, failStatus, failResponse }) => {
         expect(failStatus, 500);
         expect(failResponse, errorMessage);
+        expect(context.requestPayload, payload);
+        expect(typeof context.requestPayload, typeof payload);
         expect(context.headers.get("authentication")!, authHeaderValue);
 
         await saveResult(

--- a/src/workflow-parser.ts
+++ b/src/workflow-parser.ts
@@ -317,7 +317,9 @@ export const handleFailure = async <TInitialPayload>(
     const workflowContext = new WorkflowContext<TInitialPayload>({
       qstashClient,
       workflowRunId,
-      initialPayload: initialPayloadParser(decodeBase64(sourceBody)),
+      initialPayload: sourceBody
+        ? initialPayloadParser(decodeBase64(sourceBody))
+        : (undefined as TInitialPayload),
       headers: recreateUserHeaders(new Headers(sourceHeader) as Headers),
       steps: [],
       url: url,


### PR DESCRIPTION
when initial payload was undefined, we would try to decode it, which would result in this error Failed while decoding base64 undefined