### PR TITLE
Add timeout parameter to context.call

### DIFF
--- a/src/context/auto-executor.ts
+++ b/src/context/auto-executor.ts
@@ -374,7 +374,8 @@ export class AutoExecutor {
           singleStep,
           this.context.failureUrl,
           this.context.retries,
-          lazyStep instanceof LazyCallStep ? lazyStep.retries : undefined
+          lazyStep instanceof LazyCallStep ? lazyStep.retries : undefined,
+          lazyStep instanceof LazyCallStep ? lazyStep.timeout : undefined
         );
 
         // if the step is a single step execution or a plan step, we can add sleep headers

--- a/src/context/context.test.ts
+++ b/src/context/context.test.ts
@@ -293,6 +293,7 @@ describe("context tests", () => {
               headers: { "my-header": "my-value" },
               method: "PATCH",
               retries: retries,
+              timeout: 30,
             });
           expect(throws).toThrowError("Aborting workflow after executing step 'my-step'.");
         },
@@ -332,6 +333,7 @@ describe("context tests", () => {
                 "upstash-workflow-init": "false",
                 "upstash-workflow-runid": "wfr-id",
                 "upstash-workflow-url": WORKFLOW_ENDPOINT,
+                "upstash-timeout": "30",
               },
             },
           ],

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -287,6 +287,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
    * @param body call body
    * @param headers call headers
    * @param retries number of call retries. 0 by default
+   * @param timeout max duration to wait for the endpoint to respond
    * @returns call result as {
    *     status: number;
    *     body: unknown;
@@ -301,12 +302,21 @@ export class WorkflowContext<TInitialPayload = unknown> {
       body?: unknown;
       headers?: Record<string, string>;
       retries?: number;
+      timeout?: Duration | number;
     }
   ): Promise<CallResponse<TResult>> {
-    const { url, method = "GET", body, headers = {}, retries = 0 } = settings;
+    const { url, method = "GET", body, headers = {}, retries = 0, timeout } = settings;
 
     const result = await this.addStep(
-      new LazyCallStep<CallResponse<string> | string>(stepName, url, method, body, headers, retries)
+      new LazyCallStep<CallResponse<string> | string>(
+        stepName,
+        url,
+        method,
+        body,
+        headers,
+        retries,
+        timeout
+      )
     );
 
     // <for backwards compatibity>

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -287,7 +287,7 @@ export class WorkflowContext<TInitialPayload = unknown> {
    * @param body call body
    * @param headers call headers
    * @param retries number of call retries. 0 by default
-   * @param timeout max duration to wait for the endpoint to respond
+   * @param timeout max duration to wait for the endpoint to respond. in seconds.
    * @returns call result as {
    *     status: number;
    *     body: unknown;

--- a/src/context/steps.test.ts
+++ b/src/context/steps.test.ts
@@ -145,7 +145,7 @@ describe("test steps", () => {
     const callHeaders = {
       "my-header": headerValue,
     };
-    const step = new LazyCallStep(stepName, callUrl, callMethod, callBody, callHeaders, 14);
+    const step = new LazyCallStep(stepName, callUrl, callMethod, callBody, callHeaders, 14, 30);
 
     test("should set correct fields", () => {
       expect(step.stepName).toBe(stepName);

--- a/src/context/steps.test.ts
+++ b/src/context/steps.test.ts
@@ -291,12 +291,20 @@ describe("test steps", () => {
     test("should throw when step name is undefined ", () => {
       // @ts-expect-error allow undefined for test purposes
       const throws = () => new LazySleepStep(undefined, 10);
-      expect(throws).toThrow(new WorkflowError("step name can't be undefined or empty string."));
+      expect(throws).toThrow(
+        new WorkflowError(
+          "A workflow step name cannot be undefined or an empty string. Please provide a name for your workflow step."
+        )
+      );
     });
 
     test("should throw when step name is empty string ", () => {
       const throws = () => new LazyFunctionStep("", () => {});
-      expect(throws).toThrow(new WorkflowError("step name can't be undefined or empty string."));
+      expect(throws).toThrow(
+        new WorkflowError(
+          "A workflow step name cannot be undefined or an empty string. Please provide a name for your workflow step."
+        )
+      );
     });
   });
 });

--- a/src/context/steps.test.ts
+++ b/src/context/steps.test.ts
@@ -11,6 +11,7 @@ import { nanoid } from "../utils";
 import type { NotifyResponse, NotifyStepResponse, Step } from "../types";
 import { Client } from "@upstash/qstash";
 import { MOCK_QSTASH_SERVER_URL, mockQStashServer } from "../test-utils";
+import { WorkflowError } from "../error";
 
 describe("test steps", () => {
   const stepName = nanoid();
@@ -283,6 +284,19 @@ describe("test steps", () => {
       });
 
       expect(called).toBeTrue();
+    });
+  });
+
+  describe("stepName check", () => {
+    test("should throw when step name is undefined ", () => {
+      // @ts-expect-error allow undefined for test purposes
+      const throws = () => new LazySleepStep(undefined, 10);
+      expect(throws).toThrow(new WorkflowError("step name can't be undefined or empty string."));
+    });
+
+    test("should throw when step name is empty string ", () => {
+      const throws = () => new LazyFunctionStep("", () => {});
+      expect(throws).toThrow(new WorkflowError("step name can't be undefined or empty string."));
     });
   });
 });

--- a/src/context/steps.ts
+++ b/src/context/steps.ts
@@ -2,6 +2,7 @@ import type { Client, HTTPMethods } from "@upstash/qstash";
 import type { NotifyStepResponse, Step, StepFunction, StepType, WaitStepResponse } from "../types";
 import { makeNotifyRequest } from "../client/utils";
 import type { Duration } from "../types";
+import { WorkflowError } from "../error";
 
 /**
  * Base class outlining steps. Basically, each step kind (run/sleep/sleepUntil)
@@ -14,6 +15,9 @@ export abstract class BaseLazyStep<TResult = unknown> {
   public readonly stepName;
   public abstract readonly stepType: StepType; // will be set in the subclasses
   constructor(stepName: string) {
+    if (!stepName) {
+      throw new WorkflowError("step name can't be undefined or empty string.");
+    }
     this.stepName = stepName;
   }
 

--- a/src/context/steps.ts
+++ b/src/context/steps.ts
@@ -148,8 +148,9 @@ export class LazyCallStep<TResult = unknown, TBody = unknown> extends BaseLazySt
   private readonly method: HTTPMethods;
   private readonly body: TBody;
   private readonly headers: Record<string, string>;
-  stepType: StepType = "Call";
   public readonly retries: number;
+  public readonly timeout?: number | Duration;
+  stepType: StepType = "Call";
 
   constructor(
     stepName: string,
@@ -157,7 +158,8 @@ export class LazyCallStep<TResult = unknown, TBody = unknown> extends BaseLazySt
     method: HTTPMethods,
     body: TBody,
     headers: Record<string, string>,
-    retries: number
+    retries: number,
+    timeout: number | Duration | undefined
   ) {
     super(stepName);
     this.url = url;
@@ -165,6 +167,7 @@ export class LazyCallStep<TResult = unknown, TBody = unknown> extends BaseLazySt
     this.body = body;
     this.headers = headers;
     this.retries = retries;
+    this.timeout = timeout;
   }
 
   public getPlanStep(concurrent: number, targetStep: number): Step<undefined> {

--- a/src/context/steps.ts
+++ b/src/context/steps.ts
@@ -16,7 +16,9 @@ export abstract class BaseLazyStep<TResult = unknown> {
   public abstract readonly stepType: StepType; // will be set in the subclasses
   constructor(stepName: string) {
     if (!stepName) {
-      throw new WorkflowError("step name can't be undefined or empty string.");
+      throw new WorkflowError(
+        "A workflow step name cannot be undefined or an empty string. Please provide a name for your workflow step."
+      );
     }
     this.stepName = stepName;
   }

--- a/src/workflow-requests.ts
+++ b/src/workflow-requests.ts
@@ -14,6 +14,7 @@ import {
 } from "./constants";
 import type {
   CallResponse,
+  Duration,
   Step,
   StepType,
   WorkflowClient,
@@ -363,7 +364,8 @@ export const getHeaders = (
   step?: Step,
   failureUrl?: WorkflowServeOptions["failureUrl"],
   retries?: number,
-  callRetries?: number
+  callRetries?: number,
+  callTimeout?: number | Duration
 ): HeadersResponse => {
   const baseHeaders: Record<string, string> = {
     [WORKFLOW_INIT_HEADER]: initHeaderValue,
@@ -374,6 +376,9 @@ export const getHeaders = (
 
   if (!step?.callUrl) {
     baseHeaders[`Upstash-Forward-${WORKFLOW_PROTOCOL_VERSION_HEADER}`] = WORKFLOW_PROTOCOL_VERSION;
+  }
+  if (callTimeout) {
+    baseHeaders[`Upstash-Timeout`] = callTimeout.toString();
   }
 
   if (failureUrl) {


### PR DESCRIPTION
Adds timeout parameter to context.call:

```ts
context.call("my-step", {
  url,
  body,
  headers: { "my-header": "my-value" },
  method: "PATCH",
  retries: retries,
  timeout: 30,
});
```

Also add an error when step name is undefined or empty string.

`getHeaders` method is becoming a little to crowded, but we are planning to refactor that in the future.