### PR TITLE
Add typing support for hono variables in the handler

### DIFF
--- a/platforms/hono.ts
+++ b/platforms/hono.ts
@@ -1,6 +1,7 @@
 import type { Context } from "hono";
 import type { RouteFunction, WorkflowServeOptions } from "../src";
 import { serve as serveBase } from "../src";
+import { Variables } from "hono/types";
 
 export type WorkflowBindings = {
   QSTASH_TOKEN: string;
@@ -22,7 +23,7 @@ export type WorkflowBindings = {
 export const serve = <
   TInitialPayload = unknown,
   TBindings extends WorkflowBindings = WorkflowBindings,
-  TVariables extends object = object,
+  TVariables extends Variables = Variables,
 >(
   routeFunction: RouteFunction<TInitialPayload>,
   options?: Omit<WorkflowServeOptions<Response, TInitialPayload>, "onStepFinish">

--- a/platforms/hono.ts
+++ b/platforms/hono.ts
@@ -21,13 +21,13 @@ export type WorkflowBindings = {
  */
 export const serve = <
   TInitialPayload = unknown,
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
   TBindings extends WorkflowBindings = WorkflowBindings,
+  TVariables extends object = object,
 >(
   routeFunction: RouteFunction<TInitialPayload>,
   options?: Omit<WorkflowServeOptions<Response, TInitialPayload>, "onStepFinish">
-): ((context: Context<{ Bindings: TBindings }>) => Promise<Response>) => {
-  const handler = async (context: Context<{ Bindings: TBindings }>) => {
+): ((context: Context<{ Bindings: TBindings; Variables: TVariables }>) => Promise<Response>) => {
+  const handler = async (context: Context<{ Bindings: TBindings; Variables: TVariables }>) => {
     const environment = context.env;
     const request = context.req.raw;
 


### PR DESCRIPTION
From [discord support](https://discord.com/channels/807028371451936838/1303907030117122100/1303907030117122100)

---
https://upstash.com/docs/workflow/quickstarts/hono#step-3-create-a-workflow-endpoint in this example which showcases using hono context in the workflow serve. It only has support for Bindings. I am not able to configure or type Variables in the serve function so the handler(c) is throwing a lint error saying it cannot accept the payload. 

the following is my Hono object creation code. 
```ts
interface Bindings extends WorkflowBindings {
  db:MyDb
}
export const workflowsHandler = new Hono<{
  Variables: RootVariables;
  Bindings: Bindings;
}>();
```