### PR TITLE
Return 400 open auth failure

### DIFF
--- a/examples/ci/app/ci/constants.ts
+++ b/examples/ci/app/ci/constants.ts
@@ -50,6 +50,11 @@ export const TEST_ROUTES: Pick<TestConfig, "route" | "waitForSeconds">[] = [
     waitForSeconds: 24
   },
   {
+    // check the error when wf early returns
+    route: "returns-before-step",
+    waitForSeconds: 3
+  },
+  {
     // checks context.run with async and sync route methods
     route: "async-sync-run",
     waitForSeconds: 1

--- a/examples/ci/app/ci/types.ts
+++ b/examples/ci/app/ci/types.ts
@@ -25,6 +25,12 @@ export type TestConfig<TPayload = unknown> = {
    * expected result in the Redis
    */
   expectedResult: string
+  /**
+   * whether the workflow should start
+   * 
+   * @default true
+   */
+  workflowStarts?: boolean
 }
 
 export type RedisResult = {

--- a/examples/ci/app/ci/upstash/redis.ts
+++ b/examples/ci/app/ci/upstash/redis.ts
@@ -4,7 +4,7 @@ import { expect } from "../utils";
 import { type WorkflowContext } from "@upstash/workflow";
 import { CI_RANDOM_ID_HEADER, CI_ROUTE_HEADER } from "../constants";
 
-const redis = Redis.fromEnv();
+export const redis = Redis.fromEnv();
 const EXPIRE_IN_SECS = 60
 
 const getRedisKey = (

--- a/examples/ci/app/ci/utils.ts
+++ b/examples/ci/app/ci/utils.ts
@@ -65,14 +65,20 @@ export const getTestConfig = async (route: string) => {
 
 export const initiateTest = async (route: string, waitForSeconds: number) => {
   const randomTestId = nanoid()
-  const { headers, payload, expectedCallCount, expectedResult } = await getTestConfig(route)
+  const { headers, payload, expectedCallCount, expectedResult, workflowStarts = true } = await getTestConfig(route)
 
   const { messageId } = await qstash.startWorkflow({ route, headers, payload }, randomTestId)
 
   // sleep for 4 secs and check that message is delivered
   await new Promise(r => setTimeout(r, 4000));
 
-  await qstash.checkWorkflowStart(messageId)
+  try {
+    await qstash.checkWorkflowStart(messageId);
+  } catch (error) {
+    if (workflowStarts) {
+      throw error;
+    };
+  }
 
   await new Promise(r => setTimeout(r, waitForSeconds * 1000));
 

--- a/examples/ci/app/test-routes/auth/fail/route.ts
+++ b/examples/ci/app/test-routes/auth/fail/route.ts
@@ -40,6 +40,7 @@ export const { POST, GET } = testServe(
     headers: {
       [ header ]: headerValue,
       "authentication": authentication
-    }
+    },
+    workflowStarts: false
   }
 ) 

--- a/examples/ci/app/test-routes/call/constants.ts
+++ b/examples/ci/app/test-routes/call/constants.ts
@@ -4,3 +4,5 @@ export const FAILING_HEADER_VALUE = "fail-header-value-BAR"
 
 export const GET_HEADER = "Get-Header"
 export const GET_HEADER_VALUE = "get-header-value-FOO"
+
+export const PATCH_RESULT = 99999999

--- a/examples/ci/app/test-routes/call/third-party/route.ts
+++ b/examples/ci/app/test-routes/call/third-party/route.ts
@@ -1,4 +1,4 @@
-import { FAILING_HEADER_VALUE, FAILING_HEADER, GET_HEADER, GET_HEADER_VALUE } from "../constants";
+import { FAILING_HEADER_VALUE, FAILING_HEADER, GET_HEADER, GET_HEADER_VALUE, PATCH_RESULT } from "../constants";
 
 const thirdPartyResult = "third-party-result";
 
@@ -24,12 +24,21 @@ export const POST = async (request: Request) => {
 
 export const PATCH = async () => {
   return new Response(
-    "failing request",
+    PATCH_RESULT.toString(),
     {
       status: 401,
       headers: {
         [ FAILING_HEADER ]: FAILING_HEADER_VALUE
       }
+    }
+  )
+}
+
+export const DELETE = async () => {
+  return new Response(
+    JSON.stringify({ foo: "bar", zed: 2 }),
+    {
+      status: 400
     }
   )
 }

--- a/examples/ci/app/test-routes/call/workflow-with-failureFunction/route.ts
+++ b/examples/ci/app/test-routes/call/workflow-with-failureFunction/route.ts
@@ -2,7 +2,7 @@ import { serve } from "@upstash/workflow/nextjs";
 import { BASE_URL, TEST_ROUTE_PREFIX } from "app/ci/constants";
 import { testServe, expect } from "app/ci/utils";
 import { fail, saveResult } from "app/ci/upstash/redis"
-import { FAILING_HEADER, FAILING_HEADER_VALUE } from "../constants";
+import { FAILING_HEADER, FAILING_HEADER_VALUE, PATCH_RESULT } from "../constants";
 import { WorkflowContext } from "@upstash/workflow";
 
 const testHeader = `test-header-foo`
@@ -15,19 +15,19 @@ export const { POST, GET } = testServe(
   serve<string>(
     async (context) => {
 
-      const { body: patchResult, status, header } = await context.call("get call", {
+      const { body: patchResult, status, header } = await context.call<number>("get call", {
         url: thirdPartyEndpoint,
         method: "PATCH",
         retries: 0
       });
 
       expect(status, 401)
-      expect(patchResult as string, "failing request");
+      expect(patchResult, PATCH_RESULT);
       expect(header[FAILING_HEADER][0], FAILING_HEADER_VALUE)
       
       await saveResult(
         context,
-        patchResult as string,
+        patchResult.toString(),
       )
     }, {
       baseUrl: BASE_URL,
@@ -38,7 +38,7 @@ export const { POST, GET } = testServe(
     }
   ), {
     expectedCallCount: 4,
-    expectedResult: "failing request",
+    expectedResult: PATCH_RESULT.toString(),
     payload,
     headers: {
       [ testHeader ]: headerValue,

--- a/examples/ci/app/test-routes/call/workflow-with-failureUrl/route.ts
+++ b/examples/ci/app/test-routes/call/workflow-with-failureUrl/route.ts
@@ -2,7 +2,7 @@ import { serve } from "@upstash/workflow/nextjs";
 import { BASE_URL, TEST_ROUTE_PREFIX } from "app/ci/constants";
 import { testServe, expect } from "app/ci/utils";
 import { saveResult } from "app/ci/upstash/redis"
-import { FAILING_HEADER, FAILING_HEADER_VALUE } from "../constants";
+import { FAILING_HEADER, FAILING_HEADER_VALUE, PATCH_RESULT } from "../constants";
 
 const testHeader = `test-header-foo`
 const headerValue = `header-foo`
@@ -14,19 +14,19 @@ export const { POST, GET } = testServe(
   serve<string>(
     async (context) => {
 
-      const { body: patchResult, status, header } = await context.call("get call", {
+      const { body: patchResult, status, header } = await context.call<number>("get call", {
         url: thirdPartyEndpoint,
         method: "PATCH",
         retries: 0
       });
 
       expect(status, 401)
-      expect(patchResult as string, "failing request");
+      expect(patchResult, PATCH_RESULT);
       expect(header[FAILING_HEADER][0], FAILING_HEADER_VALUE)
       
       await saveResult(
         context,
-        patchResult as string,
+        patchResult.toString(),
       )
     }, {
       baseUrl: BASE_URL,
@@ -36,7 +36,7 @@ export const { POST, GET } = testServe(
     }
   ), {
     expectedCallCount: 4,
-    expectedResult: "failing request",
+    expectedResult: PATCH_RESULT.toString(),
     payload,
     headers: {
       [ testHeader ]: headerValue,

--- a/examples/ci/app/test-routes/returns-before-step/route.ts
+++ b/examples/ci/app/test-routes/returns-before-step/route.ts
@@ -1,0 +1,45 @@
+import { serve } from "@upstash/workflow/nextjs";
+import { BASE_URL, CI_RANDOM_ID_HEADER } from "app/ci/constants";
+import { expect, testServe } from "app/ci/utils";
+import { redis, saveResult, fail } from "app/ci/upstash/redis"
+import { WorkflowContext } from "@upstash/workflow";
+
+const secret = "super-secret-key"
+
+export const { POST, GET } = testServe(
+  serve<string>(
+    async (context) => {
+
+      const redisKey = `redis-key-${context.headers.get(CI_RANDOM_ID_HEADER)}`
+      const count = await redis.incr(redisKey)
+      if (count === 1) {
+        // allow in the first encounter
+        await context.run("mock step", () => {})
+      } else if (count === 2) {
+        // return after the step, which should return 400
+        return
+      } else if (count === 3) {
+        // coming back for failureFunction. put a mock step to allow it
+        await context.run("mock step", () => {})
+      }
+
+      // otherwise fail.
+      await fail(context);
+    }, {
+      baseUrl: BASE_URL,
+      retries: 0,
+      async failureFunction({ context, failStatus, failResponse }) {
+        expect(failStatus, 400)
+        expect(failResponse, `Failed to authenticate Workflow request. If this is unexpected, see the caveat https://upstash.com/docs/workflow/basics/caveats#avoid-non-deterministic-code-outside-context-run`)
+        await saveResult(
+          context as WorkflowContext,
+          secret
+        )
+      }
+    }
+  ), {
+    expectedCallCount: 3,
+    expectedResult: secret,
+    payload: undefined,
+  }
+)

--- a/platforms/nextjs.ts
+++ b/platforms/nextjs.ts
@@ -18,11 +18,10 @@ export const serve = <TInitialPayload = unknown>(
   routeFunction: RouteFunction<TInitialPayload>,
   options?: Omit<WorkflowServeOptions<Response, TInitialPayload>, "onStepFinish">
 ): { POST: (request: Request) => Promise<Response> } => {
-  const { handler: serveHandler } = serveBase<TInitialPayload, Request, Response>(routeFunction, {
-    onStepFinish: (workflowRunId: string) =>
-      new Response(JSON.stringify({ workflowRunId }), { status: 200 }),
-    ...options,
-  });
+  const { handler: serveHandler } = serveBase<TInitialPayload, Request, Response>(
+    routeFunction,
+    options
+  );
 
   return {
     POST: async (request: Request) => {

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -204,7 +204,7 @@ describe("workflow client", () => {
           "upstash-retries": "15",
           "upstash-workflow-init": "true",
           "upstash-workflow-runid": `wfr_${myWorkflowRunId}`,
-          "upstash-workflow-url": "https://www.my-website.com/api",
+          "upstash-workflow-url": "https://requestcatcher.com/api",
         },
       },
     });

--- a/src/serve/index.ts
+++ b/src/serve/index.ts
@@ -13,7 +13,7 @@ import {
   verifyRequest,
 } from "../workflow-requests";
 import { DisabledWorkflowContext } from "./authorization";
-import { determineUrls, processOptions } from "./options";
+import { AUTH_FAIL_MESSAGE, determineUrls, processOptions } from "./options";
 
 /**
  * Creates an async method that handles incoming requests and runs the provided
@@ -135,7 +135,11 @@ export const serve = <
     } else if (authCheck.value === "run-ended") {
       // finished routeFunction while trying to run until first step.
       // either there is no step or auth check resulted in `return`
-      return onStepFinish("no-workflow-id", "auth-fail");
+      await debug?.log("ERROR", "ERROR", { error: AUTH_FAIL_MESSAGE });
+      return onStepFinish(
+        isFirstInvocation ? "no-workflow-id" : workflowContext.workflowRunId,
+        "auth-fail"
+      );
     }
 
     // check if request is a third party call result

--- a/src/serve/options.ts
+++ b/src/serve/options.ts
@@ -35,11 +35,23 @@ export const processOptions = <TResponse extends Response = Response, TInitialPa
       baseUrl: environment.QSTASH_URL!,
       token: environment.QSTASH_TOKEN!,
     }),
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    onStepFinish: (workflowRunId: string, _finishCondition: FinishCondition) =>
-      new Response(JSON.stringify({ workflowRunId }), {
+    onStepFinish: (workflowRunId: string, finishCondition: FinishCondition) => {
+      if (finishCondition === "auth-fail") {
+        console.error(AUTH_FAIL_MESSAGE);
+        return new Response(
+          JSON.stringify({
+            message: AUTH_FAIL_MESSAGE,
+            workflowRunId,
+          }),
+          {
+            status: 400,
+          }
+        ) as TResponse;
+      }
+      return new Response(JSON.stringify({ workflowRunId }), {
         status: 200,
-      }) as TResponse,
+      }) as TResponse;
+    },
     initialPayloadParser: (initialRequest: string) => {
       // if there is no payload, simply return undefined
       if (!initialRequest) {
@@ -104,3 +116,5 @@ export const determineUrls = async <TInitialPayload = unknown>(
     workflowFailureUrl,
   };
 };
+
+export const AUTH_FAIL_MESSAGE = `Failed to authenticate Workflow request. If this is unexpected, see the caveat https://upstash.com/docs/workflow/basics/caveats#avoid-non-deterministic-code-outside-context-run`;

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -11,7 +11,7 @@ export const MOCK_QSTASH_SERVER_PORT = 8080;
 export const MOCK_QSTASH_SERVER_URL = `http://localhost:${MOCK_QSTASH_SERVER_PORT}`;
 
 export const MOCK_SERVER_URL = "https://requestcatcher.com/";
-export const WORKFLOW_ENDPOINT = "https://www.my-website.com/api";
+export const WORKFLOW_ENDPOINT = "https://requestcatcher.com/api";
 
 export type ResponseFields = {
   body: unknown;

--- a/src/workflow-requests.test.ts
+++ b/src/workflow-requests.test.ts
@@ -59,7 +59,7 @@ describe("Workflow Requests", () => {
       },
       receivesRequest: {
         method: "POST",
-        url: `${MOCK_QSTASH_SERVER_URL}/v2/publish/https://www.my-website.com/api`,
+        url: `${MOCK_QSTASH_SERVER_URL}/v2/publish/https://requestcatcher.com/api`,
         token,
         body: initialPayload,
         headers: {
@@ -562,7 +562,6 @@ describe("Workflow Requests", () => {
       });
 
       await triggerFirstInvocation(context, 3);
-
       const debug = new WorkflowLogger({ logLevel: "INFO", logOutput: "console" });
       const spy = spyOn(debug, "log");
 


### PR DESCRIPTION
We now return `status: 400` in response to auth failures. The text of the message reads:

```
Failed to authenticate Workflow request. If this is unexpected, see the caveat https://upstash.com/docs/workflow/basics/caveats#avoid-non-deterministic-code-outside-context-run
```

The caveat is being updated with https://github.com/upstash/docs/pull/336. [See the preview](https://upstash-wf-auth-fail-caveat.mintlify.app/workflow/basics/caveats#avoid-non-deterministic-code-outside-context-run)

Also did the following in the CI:
- added an endpoint which returns a json in context.call
- added workflowStarts so that we can disable checking worklfow start in auth/fail endpoint