### PR TITLE
Throw when workflow url doesn't start with http:// or https://

### DIFF
--- a/src/serve/serve.test.ts
+++ b/src/serve/serve.test.ts
@@ -693,7 +693,7 @@ describe("serve", () => {
     expect(called).toBeTrue();
   });
 
-  describe.only("incorrect url will prod client", () => {
+  describe("incorrect url will prod client", () => {
     const qstashClient = new Client({ token: process.env.QSTASH_TOKEN! });
     const client = new WorkflowClient({ token: process.env.QSTASH_TOKEN! });
 

--- a/src/workflow-requests.test.ts
+++ b/src/workflow-requests.test.ts
@@ -563,9 +563,9 @@ describe("Workflow Requests", () => {
           url: WORKFLOW_ENDPOINT,
         });
 
-      await triggerFirstInvocation(context, 3);
-      const debug = new WorkflowLogger({ logLevel: "INFO", logOutput: "console" });
-      const spy = spyOn(debug, "log");
+        await triggerFirstInvocation(context, 3);
+        const debug = new WorkflowLogger({ logLevel: "INFO", logOutput: "console" });
+        const spy = spyOn(debug, "log");
 
         const firstDelete = await triggerWorkflowDelete(context, debug);
         expect(firstDelete).toEqual({ deleted: true });


### PR DESCRIPTION
Additionally, we print a warning log if the url has localhost.