### PR TITLE
Accept baseURL in openai

### DIFF
--- a/src/agents/adapters.ts
+++ b/src/agents/adapters.ts
@@ -9,6 +9,10 @@ import { tool } from "ai";
 import { AISDKTool, LangchainTool } from "./types";
 import { AGENT_NAME_HEADER } from "./constants";
 
+type ModelParams = Parameters<ReturnType<typeof createWorkflowOpenAI>>;
+type ModelSettingsWithBaseURL = ModelParams["1"] & { baseURL?: string };
+export type ModelParamsWithBaseURL = [ModelParams[0], ModelSettingsWithBaseURL?];
+
 /**
  * creates an AI SDK openai client with a custom
  * fetch implementation which uses context.call.
@@ -16,8 +20,9 @@ import { AGENT_NAME_HEADER } from "./constants";
  * @param context workflow context
  * @returns ai sdk openai
  */
-export const createWorkflowOpenAI = (context: WorkflowContext) => {
+export const createWorkflowOpenAI = (context: WorkflowContext, baseURL?: string) => {
   return createOpenAI({
+    baseURL,
     compatibility: "strict",
     fetch: async (input, init) => {
       try {

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,5 +1,5 @@
 import { WorkflowContext } from "../context";
-import { createWorkflowOpenAI, wrapTools } from "./adapters";
+import { createWorkflowOpenAI, ModelParamsWithBaseURL, wrapTools } from "./adapters";
 import { Agent } from "./agent";
 import { Task } from "./task";
 import {
@@ -94,8 +94,10 @@ export class WorkflowAgents {
   /**
    * creates an openai model for agents
    */
-  public openai(...params: Parameters<ReturnType<typeof createWorkflowOpenAI>>) {
-    const openai = createWorkflowOpenAI(this.context);
-    return openai(...params);
+  public openai(...params: ModelParamsWithBaseURL) {
+    const [model, settings] = params;
+    const { baseURL, ...otherSettings } = settings ?? {};
+    const openai = createWorkflowOpenAI(this.context, baseURL);
+    return openai(model, otherSettings);
   }
 }

--- a/src/agents/task.test.ts
+++ b/src/agents/task.test.ts
@@ -128,11 +128,11 @@ describe("tasks", () => {
     });
   });
 
-  test("multi agent", async () => {
+  test("multi agent with baseURL", async () => {
     const { agentsApi, agent, token, workflowRunId } = getAgentsApi({ disabledContext: false });
     const task = agentsApi.task({
       agents: [agent],
-      model: agentsApi.openai("gpt-3.5-turbo"),
+      model: agentsApi.openai("gpt-3.5-turbo", { baseURL: "https://api.deepseek.com/v1" }),
       maxSteps: 2,
       prompt: "hello world!",
     });
@@ -155,7 +155,7 @@ describe("tasks", () => {
         body: [
           {
             body: '{"model":"gpt-3.5-turbo","temperature":0.1,"messages":[{"role":"system","content":"You are an agent orchestrating other AI Agents.\\n\\nThese other agents have tools available to them.\\n\\nGiven a prompt, utilize these agents to address requests.\\n\\nDon\'t always call all the agents provided to you at the same time. You can call one and use it\'s response to call another.\\n\\nAvoid calling the same agent twice in one turn. Instead, prefer to call it once but provide everything\\nyou need from that agent.\\n"},{"role":"user","content":"hello world!"}],"tools":[{"type":"function","function":{"name":"my agent","description":"An AI Agent with the following background: an agentHas access to the following tools: ai sdk tool","parameters":{"type":"object","properties":{"prompt":{"type":"string"}},"required":["prompt"],"additionalProperties":false,"$schema":"http://json-schema.org/draft-07/schema#"}}}],"tool_choice":"auto"}',
-            destination: "https://api.openai.com/v1/chat/completions",
+            destination: "https://api.deepseek.com/v1/chat/completions",
             headers: {
               "content-type": "application/json",
               "upstash-callback": "https://requestcatcher.com/api",

--- a/src/context/api/openai.ts
+++ b/src/context/api/openai.ts
@@ -1,4 +1,4 @@
-import { openai } from "@upstash/qstash";
+import { custom, openai } from "@upstash/qstash";
 import { ApiCallSettings, BaseWorkflowApi } from "./base";
 import { CallResponse } from "../../types";
 
@@ -96,16 +96,23 @@ export class OpenAIAPI extends BaseWorkflowApi {
       {
         token: string;
         organization?: string;
+        baseURL?: string;
         operation: "chat.completions.create";
       }
     >
   ): Promise<CallResponse<TResult>> {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { token, organization, operation, ...parameters } = settings;
+    const { token, organization, operation, baseURL, ...parameters } = settings;
+
+    const useOpenAI = baseURL === undefined;
+    const provider = useOpenAI
+      ? openai({ token, organization })
+      : custom({ baseUrl: baseURL, token });
+
     return await this.callApi<TResult, TBody>(stepName, {
       api: {
         name: "llm",
-        provider: openai({ token, organization }),
+        provider,
       },
       ...parameters,
     });

--- a/src/context/context.test.ts
+++ b/src/context/context.test.ts
@@ -571,6 +571,88 @@ describe("context tests", () => {
       });
     });
 
+    test("should work with custom openai compatible provider", async () => {
+      const context = new WorkflowContext({
+        qstashClient,
+        initialPayload: "my-payload",
+        steps: [],
+        url: WORKFLOW_ENDPOINT,
+        headers: new Headers() as Headers,
+        workflowRunId: "wfr-id",
+        retries: 2,
+      });
+
+      const openAIToken = `hello-there`;
+      const stepName = "call step";
+      const timeout = "10s";
+      await mockQStashServer({
+        execute: () => {
+          const throws = () =>
+            context.api.openai.call(stepName, {
+              token: openAIToken,
+              operation: "chat.completions.create",
+              baseURL: "https://api.deepseek.com",
+              timeout,
+              body: {
+                model: "gpt-4o",
+                messages: [
+                  {
+                    role: "system",
+                    content: "Assistant says hello!",
+                  },
+                  { role: "user", content: "User shouts there!" },
+                ],
+              },
+            });
+          expect(throws).toThrowError(
+            "This is an Upstash Workflow error thrown after a step executes"
+          );
+        },
+        responseFields: {
+          status: 200,
+          body: "msgId",
+        },
+        receivesRequest: {
+          method: "POST",
+          url: `${MOCK_QSTASH_SERVER_URL}/v2/batch`,
+          token,
+          body: [
+            {
+              body: '{"model":"gpt-4o","messages":[{"role":"system","content":"Assistant says hello!"},{"role":"user","content":"User shouts there!"}]}',
+              destination: "https://api.deepseek.com/v1/chat/completions",
+              headers: {
+                "upstash-timeout": timeout,
+                "content-type": "application/json",
+                "upstash-callback": WORKFLOW_ENDPOINT,
+                "upstash-callback-feature-set": "LazyFetch,InitialBody",
+                "upstash-callback-forward-upstash-workflow-callback": "true",
+                "upstash-callback-forward-upstash-workflow-concurrent": "1",
+                "upstash-callback-forward-upstash-workflow-contenttype": "application/json",
+                "upstash-callback-forward-upstash-workflow-stepid": "1",
+                "upstash-callback-forward-upstash-workflow-stepname": stepName,
+                "upstash-callback-forward-upstash-workflow-steptype": "Call",
+                "upstash-callback-retries": "2",
+                "upstash-callback-workflow-calltype": "fromCallback",
+                "upstash-callback-workflow-init": "false",
+                "upstash-callback-workflow-runid": "wfr-id",
+                "upstash-callback-workflow-url": WORKFLOW_ENDPOINT,
+                "upstash-failure-callback-retries": "2",
+                "upstash-feature-set": "WF_NoDelete,InitialBody",
+                "upstash-forward-authorization": `Bearer ${openAIToken}`,
+                "upstash-forward-content-type": "application/json",
+                "upstash-method": "POST",
+                "upstash-retries": "0",
+                "upstash-workflow-calltype": "toCallback",
+                "upstash-workflow-init": "false",
+                "upstash-workflow-runid": "wfr-id",
+                "upstash-workflow-url": WORKFLOW_ENDPOINT,
+              },
+            },
+          ],
+        },
+      });
+    });
+
     test("should work with resend provider", async () => {
       const context = new WorkflowContext({
         qstashClient,


### PR DESCRIPTION
Adds optional baseURL parameters to `context.api.openai.call` and `context.agents.openai`:

`context.api.openai.call`:

```ts
context.api.openai.call(stepName, {
  token: openAIToken,
  operation: "chat.completions.create",
  baseURL: "https://api.deepseek.com",
  timeout,
  body: {
    model: "gpt-4o",
    messages: [
      {
        role: "system",
        content: "Assistant says hello!",
      },
      { role: "user", content: "User shouts there!" },
    ],
  },
})
```

`context.agents.openai`:

```ts
context.agents.openai("gpt-3.5-turbo", { baseURL: "https://api.deepseek.com/v1" })
```
