### PR TITLE
Add WorkflowTool

### DIFF
--- a/src/agents/adapters.test.ts
+++ b/src/agents/adapters.test.ts
@@ -43,7 +43,7 @@ describe("wrapTools", () => {
     description: workflowToolDescription,
     schema: parameters,
     invoke: execute,
-    wrap: true
+    executeAsStep: true
   })
 
   test("should wrap AI SDK tool with execute", async () => {
@@ -169,7 +169,7 @@ describe("wrapTools", () => {
       invoke: async ({ expression }) => {
         await context.sleep(`step ${expression}`, 1000)
       },
-      wrap: false
+      executeAsStep: false
     })
 
     const wrappedTools = wrapTools({ context, tools: { nonwrappedWorkflowTool } });

--- a/src/agents/adapters.test.ts
+++ b/src/agents/adapters.test.ts
@@ -3,7 +3,7 @@ import { WorkflowContext } from "../context";
 import { Client } from "@upstash/qstash";
 import { MOCK_QSTASH_SERVER_URL, mockQStashServer, WORKFLOW_ENDPOINT } from "../test-utils";
 import { getWorkflowRunId, nanoid } from "../utils";
-import { wrapTools } from "./adapters";
+import { WorkflowTool, wrapTools } from "./adapters";
 import { tool } from "ai";
 import { z } from "zod";
 import { LangchainTool } from "./types";
@@ -23,6 +23,7 @@ describe("wrapTools", () => {
 
   const aiSDKToolDescription = "ai sdk tool";
   const langChainToolDescription = "langchain sdk tool";
+  const workflowToolDescription = "workflow tool";
   const parameters = z.object({ expression: z.string() });
   const execute = async ({ expression }: { expression: string }) => expression;
 
@@ -38,6 +39,13 @@ describe("wrapTools", () => {
     invoke: execute,
   };
 
+  const wrappedWorkflowTool = new WorkflowTool({
+    description: workflowToolDescription,
+    schema: parameters,
+    invoke: execute,
+    wrap: true
+  })
+
   test("should wrap AI SDK tool with execute", async () => {
     const context = createContext();
     const wrappedTools = wrapTools({ context, tools: { aiSDKTool } });
@@ -45,7 +53,7 @@ describe("wrapTools", () => {
     expect(Object.entries(wrappedTools).length).toBe(1);
     const wrappedTool = wrappedTools["aiSDKTool"];
     // @ts-expect-error description exists but can't resolve the type
-    expect(wrappedTool.description === aiSDKToolDescription).toBeTrue();
+    expect(wrappedTool.description).toBe(aiSDKToolDescription)
 
     await mockQStashServer({
       execute: () => {
@@ -87,6 +95,7 @@ describe("wrapTools", () => {
       },
     });
   });
+
   test("should wrap LangChain tool with execute", async () => {
     const context = createContext();
     const wrappedTools = wrapTools({ context, tools: { langChainTool } });
@@ -94,7 +103,7 @@ describe("wrapTools", () => {
     expect(Object.entries(wrappedTools).length).toBe(1);
     const wrappedTool = wrappedTools["langChainTool"];
     // @ts-expect-error description exists but can't resolve the type
-    expect(wrappedTool.description === langChainToolDescription).toBeTrue();
+    expect(wrappedTool.description).toBe(langChainToolDescription)
 
     await mockQStashServer({
       execute: () => {
@@ -136,6 +145,7 @@ describe("wrapTools", () => {
       },
     });
   });
+
   test("should wrap multiple tools", async () => {
     const context = createContext();
     const wrappedTools = wrapTools({ context, tools: { langChainTool, aiSDKTool } });
@@ -143,10 +153,120 @@ describe("wrapTools", () => {
     expect(Object.entries(wrappedTools).length).toBe(2);
     const wrappedLangChainTool = wrappedTools["langChainTool"];
     // @ts-expect-error description exists but can't resolve the type
-    expect(wrappedLangChainTool.description === langChainToolDescription).toBeTrue();
+    expect(wrappedLangChainTool.description).toBe(langChainToolDescription)
 
     const wrappedAiSDKTool = wrappedTools["aiSDKTool"];
     // @ts-expect-error description exists but can't resolve the type
-    expect(wrappedAiSDKTool.description === aiSDKToolDescription).toBeTrue();
+    expect(wrappedAiSDKTool.description).toBe(aiSDKToolDescription)
+  });
+
+  test("should skip wrapping when wrap is false", async () => {
+    const context = createContext();
+
+    const nonwrappedWorkflowTool = new WorkflowTool({
+      description: workflowToolDescription,
+      schema: parameters,
+      invoke: async ({ expression }) => {
+        await context.sleep(`step ${expression}`, 1000)
+      },
+      wrap: false
+    })
+
+    const wrappedTools = wrapTools({ context, tools: { nonwrappedWorkflowTool } });
+
+    expect(Object.entries(wrappedTools).length).toBe(1);
+    const wrappedTool = wrappedTools["nonwrappedWorkflowTool"];
+    // @ts-expect-error description exists but can't resolve the type
+    expect(wrappedTool.description).toBe(workflowToolDescription);
+
+    await mockQStashServer({
+      execute: () => {
+        const execute = wrappedTool.execute;
+        if (!execute) {
+          throw new Error("execute is missing.");
+        } else {
+          const expression = "hello";
+          const throws = () => execute({ expression }, { messages: [], toolCallId: "id" });
+          expect(throws).toThrow("Aborting workflow after executing step 'step hello'.");
+        }
+      },
+      responseFields: {
+        status: 200,
+        body: "msgId",
+      },
+      receivesRequest: {
+        method: "POST",
+        url: `${MOCK_QSTASH_SERVER_URL}/v2/batch`,
+        token,
+        body: [
+          {
+            body: "{\"stepId\":1,\"stepName\":\"step hello\",\"stepType\":\"SleepFor\",\"sleepFor\":1000,\"concurrent\":1}",
+            destination: WORKFLOW_ENDPOINT,
+            headers: {
+              "content-type": "application/json",
+              "upstash-delay": "1000s",
+              "upstash-failure-callback-retries": "3",
+              "upstash-feature-set": "LazyFetch,InitialBody",
+              "upstash-forward-upstash-workflow-sdk-version": "1",
+              "upstash-method": "POST",
+              "upstash-retries": "3",
+              "upstash-workflow-init": "false",
+              "upstash-workflow-runid": workflowRunId,
+              "upstash-workflow-url": "https://requestcatcher.com/api",
+            },
+          },
+        ],
+      },
+    });
+  })
+
+  test("should wrap when wrap is true", async () => {
+    const context = createContext();
+    const wrappedTools = wrapTools({ context, tools: { wrappedWorkflowTool } });
+
+    expect(Object.entries(wrappedTools).length).toBe(1);
+    const wrappedTool = wrappedTools["wrappedWorkflowTool"];
+    // @ts-expect-error description exists but can't resolve the type
+    expect(wrappedTool.description).toBe(workflowToolDescription)
+
+    await mockQStashServer({
+      execute: () => {
+        const execute = wrappedTool.execute;
+        if (!execute) {
+          throw new Error("execute is missing.");
+        } else {
+          const throws = () => execute({ expression: "hello" }, { messages: [], toolCallId: "id" });
+          expect(throws).toThrowError(
+            `Aborting workflow after executing step 'Run tool wrappedWorkflowTool'`
+          );
+        }
+      },
+      responseFields: {
+        status: 200,
+        body: "msgId",
+      },
+      receivesRequest: {
+        method: "POST",
+        url: `${MOCK_QSTASH_SERVER_URL}/v2/batch`,
+        token,
+        body: [
+          {
+            body: '{"stepId":1,"stepName":"Run tool wrappedWorkflowTool","stepType":"Run","out":"\\"hello\\"","concurrent":1}',
+            destination: WORKFLOW_ENDPOINT,
+            headers: {
+              "content-type": "application/json",
+              "upstash-failure-callback-retries": "3",
+              "upstash-feature-set": "LazyFetch,InitialBody",
+              "upstash-forward-upstash-workflow-sdk-version": "1",
+              "upstash-method": "POST",
+              "upstash-retries": "3",
+              "upstash-workflow-init": "false",
+              "upstash-workflow-runid": workflowRunId,
+              "upstash-workflow-url": "https://requestcatcher.com/api",
+            },
+          },
+        ],
+      },
+    });
   });
 });

--- a/src/agents/adapters.ts
+++ b/src/agents/adapters.ts
@@ -165,7 +165,16 @@ export class WorkflowTool<TSchema extends ZodType = ZodType> implements Langchai
      */
     invoke: (params: z.infer<TSchema>) => any;
     /**
-     * whether the invoke method is to be wrapped with context.run
+     * whether the invoke method is to be wrapped with `context.run`.
+     * 
+     * When you pass a LangChain, AI SDK tool or a WorkflowTool to your agent,
+     * the execute/invoke method of the tool is wrapped with `context.run` by default.
+     * 
+     * This option allows you to disable this behavior.
+     * 
+     * You may want to disable wrapping with context.run if you want to run context.run,
+     * context.call or any other workflow step yourself in the execute/invoke method
+     * of the tool.
      * 
      * @default true
      */

--- a/src/agents/adapters.ts
+++ b/src/agents/adapters.ts
@@ -97,11 +97,11 @@ export const wrapTools = ({
     Object.entries(tools).map((toolInfo) => {
       const [toolName, tool] = toolInfo;
 
-      const wrap = "wrap" in tool ? tool.wrap : true;
+      const executeAsStep = "executeAsStep" in tool ? tool.executeAsStep : true;
       const aiSDKTool: AISDKTool = convertToAISDKTool(tool);
 
       const execute = aiSDKTool.execute;
-      if (execute && wrap) {
+      if (execute && executeAsStep) {
         const wrappedExecute = (...params: Parameters<typeof execute>) => {
           return context.run(`Run tool ${toolName}`, () => execute(...params));
         };
@@ -139,17 +139,29 @@ const convertLangchainTool = (langchainTool: LangchainTool): AISDKTool => {
 };
 
 export class WorkflowTool<TSchema extends ZodType = ZodType> implements LangchainTool {
+  /**
+   * description of the tool
+   */
   public readonly description: string;
+  /**
+   * schema of the tool
+   */
   public readonly schema: TSchema;
+  /**
+   * function to invoke the tool
+   */
   public readonly invoke: (params: z.infer<TSchema>) => any;
-  public readonly wrap: boolean;
+  /**
+   * whether the invoke method of the tool is to be wrapped with `context.run`
+   */
+  public readonly executeAsStep: boolean;
 
   /**
    * 
    * @param description description of the tool
    * @param schema schema of the tool
    * @param invoke function to invoke the tool
-   * @param wrap whether to wrap the tool with context.run. True by default
+   * @param executeAsStep whether the invoke method of the tool is to be wrapped with `context.run`
    */
   constructor(params: {
     /**
@@ -178,11 +190,11 @@ export class WorkflowTool<TSchema extends ZodType = ZodType> implements Langchai
      * 
      * @default true
      */
-    wrap?: boolean;
+    executeAsStep?: boolean;
   }) {
     this.description = params.description;
     this.schema = params.schema;
     this.invoke = params.invoke;
-    this.wrap = params.wrap ?? true;
+    this.executeAsStep = params.executeAsStep ?? true;
   }
 }

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -1,6 +1,6 @@
 import type { CoreTool, generateText } from "ai";
 import { Agent } from "./agent";
-import { createWorkflowOpenAI } from "./adapters";
+import { createWorkflowOpenAI, WorkflowTool } from "./adapters";
 
 export type AISDKTool = CoreTool;
 export type LangchainTool = {
@@ -14,7 +14,7 @@ type GenerateTextParams = Parameters<typeof generateText>[0];
 
 export type Model = GenerateTextParams["model"];
 
-export type AgentParameters<TTool extends AISDKTool | LangchainTool = AISDKTool> = {
+export type AgentParameters<TTool extends AISDKTool | LangchainTool | WorkflowTool = AISDKTool> = {
   /**
    * number of times the agent can call the LLM at most. If
    * the agent abruptly stops execution after calling tools, you may need

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -20,15 +20,15 @@ export class Client {
   private client: QStashClient;
 
   constructor(clientConfig: ClientConfig) {
-    if (!clientConfig.token) {
+    if (!clientConfig?.token) {
       console.error(
         "QStash token is required for Upstash Workflow!\n\n" +
-          "To fix this:\n" +
-          "1. Get your token from the Upstash Console (https://console.upstash.com/qstash)\n" +
-          "2. Initialize the workflow client with:\n\n" +
-          "   const client = new Client({\n" +
-          "     token: '<YOUR_QSTASH_TOKEN>'\n" +
-          "   });"
+        "To fix this:\n" +
+        "1. Get your token from the Upstash Console (https://console.upstash.com/qstash)\n" +
+        "2. Initialize the workflow client with:\n\n" +
+        "   const client = new Client({\n" +
+        "     token: '<YOUR_QSTASH_TOKEN>'\n" +
+        "   });"
       );
     }
     this.client = new QStashClient(clientConfig);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export * from "./types";
 export * from "./logger";
 export * from "./client";
 export { WorkflowError, WorkflowAbort } from "./error";
+export { WorkflowTool } from "./agents/adapters"


### PR DESCRIPTION
WorkflowTool will make it possible to define a tool which doesn't wrap invoke:

```ts
import { WorkflowTool } from "@upstash/workflow"

const agent = context.agents.agent({
  tools: {
    nonwrappedWorkflowTool: new WorkflowTool({
      description: workflowToolDescription,
      schema: parameters,
      invoke: async ({ expression }) => {
        await context.sleep(`step ${expression}`, 1000)
      },
      wrap: false
    })
  }
  ...
})
```