### PR TITLE
Fix add bindings and variables generics to hono `createWorkflow`

### DIFF
--- a/platforms/hono.ts
+++ b/platforms/hono.ts
@@ -51,8 +51,13 @@ export const serve = <
   return handler;
 };
 
-export const createWorkflow = <TInitialPayload, TResult>(
-  ...params: Parameters<typeof serve<TInitialPayload, WorkflowBindings, Variables, TResult>>
+export const createWorkflow = <
+  TInitialPayload = unknown,
+  TResult = unknown,
+  TBindings extends WorkflowBindings = WorkflowBindings,
+  TVariables extends Variables = Variables,
+>(
+  ...params: Parameters<typeof serve<TInitialPayload, TBindings, TVariables, TResult>>
 ): InvokableWorkflow<TInitialPayload, TResult> => {
   const [routeFunction, options = {}] = params;
   return {


### PR DESCRIPTION
Unlike the `serve` method in hono, `createWorkflow` method was missing the generics for Variables and Bindings.

This was noted by a user in discord ([link](https://discord.com/channels/807028371451936838/1343233001651306588)).

This PR fixes the issue by adding the generics available in `serve` to `createWorkflow`.