### PR TITLE
DX-1680: Send correct content-type in context-call

### DIFF
--- a/examples/ci/app/test-routes/call/constants.ts
+++ b/examples/ci/app/test-routes/call/constants.ts
@@ -6,3 +6,5 @@ export const GET_HEADER = "Get-Header"
 export const GET_HEADER_VALUE = "get-header-value-FOO"
 
 export const PATCH_RESULT = 99999999
+
+export const CUSTOM_CONTENT_TYPE = "application/x-www-form-urlencoded"

--- a/examples/ci/app/test-routes/call/third-party/route.ts
+++ b/examples/ci/app/test-routes/call/third-party/route.ts
@@ -1,4 +1,5 @@
-import { FAILING_HEADER_VALUE, FAILING_HEADER, GET_HEADER, GET_HEADER_VALUE, PATCH_RESULT } from "../constants";
+import { expect } from "app/ci/utils";
+import { FAILING_HEADER_VALUE, FAILING_HEADER, GET_HEADER, GET_HEADER_VALUE, PATCH_RESULT, CUSTOM_CONTENT_TYPE } from "../constants";
 
 const thirdPartyResult = "third-party-result";
 
@@ -8,13 +9,15 @@ export const GET = async (request: Request) => {
     {
       status: 200,
       headers: {
-        [ GET_HEADER ]: GET_HEADER_VALUE
+        [GET_HEADER]: GET_HEADER_VALUE
       }
     }
   )
 }
 
 export const POST = async (request: Request) => {
+
+  expect(request.headers.get("content-type"), CUSTOM_CONTENT_TYPE);
 
   return new Response(
     `called POST '${thirdPartyResult}' '${request.headers.get("post-header")}' '${await request.text()}'`,
@@ -28,7 +31,7 @@ export const PATCH = async () => {
     {
       status: 401,
       headers: {
-        [ FAILING_HEADER ]: FAILING_HEADER_VALUE
+        [FAILING_HEADER]: FAILING_HEADER_VALUE
       }
     }
   )

--- a/examples/ci/app/test-routes/call/workflow/route.ts
+++ b/examples/ci/app/test-routes/call/workflow/route.ts
@@ -2,7 +2,7 @@ import { serve } from "@upstash/workflow/nextjs";
 import { BASE_URL, TEST_ROUTE_PREFIX } from "app/ci/constants";
 import { testServe, expect } from "app/ci/utils";
 import { saveResult } from "app/ci/upstash/redis"
-import { FAILING_HEADER, FAILING_HEADER_VALUE, GET_HEADER, GET_HEADER_VALUE, PATCH_RESULT } from "../constants";
+import { CUSTOM_CONTENT_TYPE, FAILING_HEADER, FAILING_HEADER_VALUE, GET_HEADER, GET_HEADER_VALUE, PATCH_RESULT } from "../constants";
 
 const testHeader = `test-header-foo`
 const headerValue = `header-foo`
@@ -11,6 +11,7 @@ const payload = "my-payload"
 const thirdPartyEndpoint = `${TEST_ROUTE_PREFIX}/call/third-party`
 const postHeader = {
   "post-header": "post-header-value-x",
+  "content-type": CUSTOM_CONTENT_TYPE
 };
 const getHeader = {
   "get-header": "get-header-value-x",
@@ -38,18 +39,18 @@ export const { POST, GET } = testServe(
       // check payload after first step because we can't check above
       expect(input, payload);
       expect(postStatus, 201)
-      
-      expect(postResult as string, 
+
+      expect(postResult as string,
         "called POST 'third-party-result' 'post-header-value-x' '\"post-payload\"'"
       );
-      
+
       await context.sleep("sleep 1", 2);
-      
+
       const { body: getResult, header: getHeaders, status: getStatus } = await context.call<string>("get call", {
         url: thirdPartyEndpoint,
         headers: getHeader,
       });
-      
+
       expect(getStatus, 200)
       expect(getHeaders[GET_HEADER][0], GET_HEADER_VALUE)
       expect(getResult, "called GET 'third-party-result' 'get-header-value-x'");
@@ -91,15 +92,15 @@ export const { POST, GET } = testServe(
         getResult
       )
     }, {
-      baseUrl: BASE_URL,
-      retries: 0
-    }
-  ), {
-    expectedCallCount: 14,
-    expectedResult: "called GET 'third-party-result' 'get-header-value-x'",
-    payload,
-    headers: {
-      [ testHeader ]: headerValue,
-    }
+    baseUrl: BASE_URL,
+    retries: 0
   }
+  ), {
+  expectedCallCount: 14,
+  expectedResult: "called GET 'third-party-result' 'get-header-value-x'",
+  payload,
+  headers: {
+    [testHeader]: headerValue,
+  }
+}
 ) 

--- a/src/context/auto-executor.ts
+++ b/src/context/auto-executor.ts
@@ -400,7 +400,7 @@ export class AutoExecutor {
       throw new WorkflowAbort(invokeStep.stepName, invokeStep);
     }
 
-    const result = await this.context.qstashClient.batchJSON(
+    const result = await this.context.qstashClient.batch(
       steps.map((singleStep, index) => {
         const lazyStep = lazySteps[index];
         const { headers } = getHeaders({
@@ -434,7 +434,7 @@ export class AutoExecutor {
             {
               headers,
               method: singleStep.callMethod,
-              body: singleStep.callBody,
+              body: JSON.stringify(singleStep.callBody),
               url: singleStep.callUrl,
             }
           : // if the step is not a third party call, we use workflow
@@ -443,7 +443,7 @@ export class AutoExecutor {
             {
               headers,
               method: "POST",
-              body: singleStep,
+              body: JSON.stringify(singleStep),
               url: this.context.url,
               notBefore: willWait ? singleStep.sleepUntil : undefined,
               delay: willWait ? singleStep.sleepFor : undefined,
@@ -451,8 +451,9 @@ export class AutoExecutor {
       })
     );
 
+    const _result = result as { messageId: string }[];
     await this.debug?.log("INFO", "SUBMIT_STEP", {
-      messageIds: result.map((message) => {
+      messageIds: _result.map((message) => {
         return {
           message: message.messageId,
         };

--- a/src/context/context.test.ts
+++ b/src/context/context.test.ts
@@ -304,7 +304,10 @@ describe("context tests", () => {
             context.call("my-step", {
               url,
               body,
-              headers: { "my-header": "my-value" },
+              headers: {
+                "my-header": "my-value",
+                "content-type": "application/x-www-form-urlencoded",
+              },
               method: "PATCH",
               retries: retries,
               timeout: 30,
@@ -325,12 +328,14 @@ describe("context tests", () => {
               destination: url,
               headers: {
                 "upstash-workflow-sdk-version": "1",
-                "content-type": "application/json",
+                "content-type": "application/x-www-form-urlencoded",
+                "upstash-forward-content-type": "application/x-www-form-urlencoded",
                 "upstash-callback": WORKFLOW_ENDPOINT,
                 "upstash-callback-feature-set": "LazyFetch,InitialBody",
                 "upstash-callback-forward-upstash-workflow-callback": "true",
                 "upstash-callback-forward-upstash-workflow-concurrent": "1",
-                "upstash-callback-forward-upstash-workflow-contenttype": "application/json",
+                "upstash-callback-forward-upstash-workflow-contenttype":
+                  "application/x-www-form-urlencoded",
                 "upstash-callback-forward-upstash-workflow-invoke-count": "7",
                 "upstash-callback-forward-upstash-workflow-stepid": "1",
                 "upstash-callback-forward-upstash-workflow-stepname": "my-step",

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
  * Neeeded to resolve import issues
  */
 export type WorkflowClient = {
+  batch: InstanceType<typeof Client>["batch"];
   batchJSON: InstanceType<typeof Client>["batchJSON"];
   publishJSON: InstanceType<typeof Client>["publishJSON"];
   publish: InstanceType<typeof Client>["publish"];

--- a/src/workflow-requests.ts
+++ b/src/workflow-requests.ts
@@ -424,8 +424,13 @@ export const getHeaders = ({
   flowControl,
   callFlowControl,
 }: HeaderParams): HeadersResponse => {
+  const callHeaders = new Headers(step?.callHeaders);
   const contentType =
-    (userHeaders ? userHeaders.get("Content-Type") : undefined) ?? DEFAULT_CONTENT_TYPE;
+    (callHeaders.get("content-type")
+      ? callHeaders.get("content-type")
+      : userHeaders?.get("Content-Type")
+        ? userHeaders.get("Content-Type")
+        : undefined) ?? DEFAULT_CONTENT_TYPE;
 
   const baseHeaders: Record<string, string> = {
     [WORKFLOW_INIT_HEADER]: initHeaderValue,


### PR DESCRIPTION
in context.call, if the user provided content-type, we were sending it like , but QStash ignores this if there is a  header.

since batchJSON added the content-type: application/json, we were unable to change the content-type. In the new version, we use batch instead of batchJSON and use the headers provided in the step as content-type if they are given.

fixes https://github.com/upstash/workflow-js/issues/70