### PR TITLE
feat: add onError support to serve

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -56,6 +56,8 @@ export const formatWorkflowError = (error: unknown): FailureFunctionPayload => {
       }
     : {
         error: "Error",
-        message: "An error occured while executing workflow.",
+        message:
+          "An error occured while executing workflow: " +
+          `'${typeof error === "string" ? error : JSON.stringify(error)}'`,
       };
 };

--- a/src/serve/index.ts
+++ b/src/serve/index.ts
@@ -62,6 +62,7 @@ export const serveBase = <
     useJSONContent,
     disableTelemetry,
     flowControl,
+    onError
   } = processOptions<TResponse, TInitialPayload>(options);
   telemetry = disableTelemetry ? undefined : telemetry;
   const debug = WorkflowLogger.getLogger(verbose);
@@ -234,7 +235,7 @@ export const serveBase = <
     try {
       return await handler(request);
     } catch (error) {
-      console.error(error);
+      onError?.(error as Error);
       return new Response(JSON.stringify(formatWorkflowError(error)), {
         status: 500,
       }) as TResponse;

--- a/src/serve/index.ts
+++ b/src/serve/index.ts
@@ -62,7 +62,7 @@ export const serveBase = <
     useJSONContent,
     disableTelemetry,
     flowControl,
-    onError
+    onError,
   } = processOptions<TResponse, TInitialPayload>(options);
   telemetry = disableTelemetry ? undefined : telemetry;
   const debug = WorkflowLogger.getLogger(verbose);
@@ -235,8 +235,21 @@ export const serveBase = <
     try {
       return await handler(request);
     } catch (error) {
-      onError?.(error as Error);
-      return new Response(JSON.stringify(formatWorkflowError(error)), {
+      const formattedError = formatWorkflowError(error);
+      try {
+        onError?.(error as Error);
+      } catch (onErrorError) {
+        const formattedOnErrorError = formatWorkflowError(onErrorError);
+        const errorMessage =
+          `Error while running onError callback: '${formattedOnErrorError.message}'.` +
+          `\nOriginal error: '${formattedError.message}'`;
+
+        console.error(errorMessage);
+        return new Response(errorMessage, {
+          status: 500,
+        }) as TResponse;
+      }
+      return new Response(JSON.stringify(formattedError), {
         status: 500,
       }) as TResponse;
     }

--- a/src/serve/options.ts
+++ b/src/serve/options.ts
@@ -26,6 +26,7 @@ export const processOptions = <TResponse extends Response = Response, TInitialPa
   | "receiver"
   | "url"
   | "failureFunction"
+  | "onError"
   | "failureUrl"
   | "baseUrl"
   | "schema"

--- a/src/serve/options.ts
+++ b/src/serve/options.ts
@@ -26,7 +26,6 @@ export const processOptions = <TResponse extends Response = Response, TInitialPa
   | "receiver"
   | "url"
   | "failureFunction"
-  | "onError"
   | "failureUrl"
   | "baseUrl"
   | "schema"
@@ -92,6 +91,7 @@ export const processOptions = <TResponse extends Response = Response, TInitialPa
     retries: DEFAULT_RETRIES,
     useJSONContent: false,
     disableTelemetry: false,
+    onError: console.error,
     ...options,
   };
 };

--- a/src/serve/serve.test.ts
+++ b/src/serve/serve.test.ts
@@ -253,6 +253,7 @@ describe("serve", () => {
   });
 
   test("should return 500 on error during step execution", async () => {
+    let onErrorCalled = false;
     const { handler: endpoint } = serve(
       async (context) => {
         await context.run("wrong step", async () => {
@@ -262,6 +263,11 @@ describe("serve", () => {
       {
         qstashClient,
         receiver: undefined,
+        onError(error) {
+          expect(error).toBeInstanceOf(Error);
+          expect(error.message).toBe("some-error");
+          onErrorCalled = true;
+        },
       }
     );
 
@@ -284,6 +290,7 @@ describe("serve", () => {
       receivesRequest: false,
     });
     expect(called).toBeTrue();
+    expect(onErrorCalled).toBeTrue();
   });
 
   test("should call onFinish with auth-fail if authentication fails", async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -173,6 +173,14 @@ export type WorkflowServeOptions<
    * Url to call if QStash retries are exhausted while executing the workflow
    */
   failureUrl?: string;
+
+  /**
+   * Error handler called when an error occurs in the workflow. This is
+   * different from `failureFunction` in that it is called when an error
+   * occurs in the workflow, while `failureFunction` is called when QStash
+   * retries are exhausted.
+   */
+  onError?: (error: Error) => void;
   /**
    * Failure function called when QStash retries are exhausted while executing
    * the workflow. Will overwrite `failureUrl` parameter with the workflow


### PR DESCRIPTION
# Add `onError` Support to Workflow Serve Function

## Summary

This PR adds a new `onError` callback option to the `serve` function, allowing users to provide custom error handling logic when errors occur during workflow execution.

## Motivation

Previously, when errors occurred during workflow execution, they were simply logged to the console with `console.error(error)`. This made it difficult for users to:

1. Implement custom error logging/monitoring
2. Handle specific error types differently
3. Collect error data for debugging purposes

The new `onError` callback gives users full control over error handling while still maintaining the default response behavior.

## Implementation Details

- Added `onError` option to the `WorkflowServeOptions` type
- Added clear JSDoc documentation explaining the difference between `onError` and `failureFunction`
- Updated error handling in `serveBase` to use the provided handler if available

## Usage Example

```typescript
serve(async (context) => {
  throw new Error("Unknown error")
},{
  // ... other options
  onError: (error) => {
    // Custom error handling
    console.error("Workflow execution failed:", error);
    
    // You could also send to error monitoring services
    Sentry.captureException(error);
  }
});
```
