### PR TITLE
DX-1792: Allow passing context.call settings when defining agent

### DIFF
--- a/src/agents/agent.test.ts
+++ b/src/agents/agent.test.ts
@@ -33,7 +33,18 @@ describe("agents", () => {
   const maxSteps = 2;
   const name = "my agent";
   const temparature = 0.4;
-  const model = agentsApi.openai("gpt-3.5-turbo");
+
+  const flowControlKey = "flowControlKey";
+  const model = agentsApi.openai("gpt-3.5-turbo", {
+    callSettings: {
+      flowControl: {
+        key: flowControlKey,
+        parallelism: 2,
+      },
+      retries: 5,
+      timeout: 10,
+    },
+  });
 
   const agent = new Agent(
     {
@@ -103,12 +114,15 @@ describe("agents", () => {
                 "upstash-forward-content-type": "application/json",
                 "upstash-forward-upstash-agent-name": "my agent",
                 "upstash-method": "POST",
-                "upstash-retries": "0",
                 "upstash-workflow-calltype": "toCallback",
                 "upstash-workflow-init": "false",
                 "upstash-workflow-runid": workflowRunId,
                 "upstash-workflow-url": "https://requestcatcher.com/api",
                 "upstash-callback-retries": "5",
+                "upstash-flow-control-key": "flowControlKey",
+                "upstash-flow-control-value": "parallelism=2",
+                "upstash-retries": "5",
+                "upstash-timeout": "10",
               },
             },
           ],
@@ -168,11 +182,14 @@ describe("agents", () => {
                 "upstash-forward-content-type": "application/json",
                 "upstash-forward-upstash-agent-name": "my agent",
                 "upstash-method": "POST",
-                "upstash-retries": "0",
                 "upstash-workflow-calltype": "toCallback",
                 "upstash-workflow-init": "false",
                 "upstash-workflow-runid": workflowRunId,
                 "upstash-workflow-url": "https://requestcatcher.com/api",
+                "upstash-flow-control-key": "flowControlKey",
+                "upstash-flow-control-value": "parallelism=2",
+                "upstash-retries": "5",
+                "upstash-timeout": "10",
               },
             },
           ],
@@ -231,11 +248,14 @@ describe("agents", () => {
               "upstash-forward-content-type": "application/json",
               "upstash-forward-upstash-agent-name": "manager llm",
               "upstash-method": "POST",
-              "upstash-retries": "0",
               "upstash-workflow-calltype": "toCallback",
               "upstash-workflow-init": "false",
               "upstash-workflow-runid": workflowRunId,
               "upstash-workflow-url": "https://requestcatcher.com/api",
+              "upstash-flow-control-key": "flowControlKey",
+              "upstash-flow-control-value": "parallelism=2",
+              "upstash-retries": "5",
+              "upstash-timeout": "10",
             },
           },
         ],

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -95,12 +95,13 @@ export class WorkflowAgents {
    */
   public openai(...params: CustomModelParams) {
     const [model, settings] = params;
-    const { baseURL, apiKey, ...otherSettings } = settings ?? {};
+    const { baseURL, apiKey, callSettings, ...otherSettings } = settings ?? {};
 
     const openaiModel = this.AISDKModel({
       context: this.context,
       provider: createOpenAI,
       providerParams: { baseURL, apiKey, compatibility: "strict" },
+      agentCallParams: callSettings,
     });
 
     return openaiModel(model, otherSettings);

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -1,6 +1,8 @@
 import type { CoreTool, generateText } from "ai";
 import { Agent } from "./agent";
-import { createWorkflowOpenAI, WorkflowTool } from "./adapters";
+import { WorkflowTool } from "./adapters";
+import { CallSettings } from "../types";
+import { createOpenAI } from "@ai-sdk/openai";
 
 export type AISDKTool = CoreTool;
 export type LangchainTool = {
@@ -90,8 +92,11 @@ export type ManagerAgentParameters = {
 } & Pick<Partial<AgentParameters>, "name" | "background"> &
   Pick<AgentParameters, "maxSteps">;
 
-type ModelParams = Parameters<ReturnType<typeof createWorkflowOpenAI>>;
-type CustomModelSettings = ModelParams["1"] & { baseURL?: string; apiKey?: string };
+type ModelParams = Parameters<ReturnType<typeof createOpenAI>>;
+export type AgentCallParams = Pick<CallSettings, "flowControl" | "retries" | "timeout">;
+type CustomModelSettings = ModelParams["1"] & { baseURL?: string; apiKey?: string } & {
+  callSettings: AgentCallParams;
+};
 export type CustomModelParams = [ModelParams[0], CustomModelSettings?];
 
 export type ProviderFunction = (params: {

--- a/src/context/auto-executor.ts
+++ b/src/context/auto-executor.ts
@@ -60,7 +60,7 @@ export class AutoExecutor {
     if (this.executingStep) {
       throw new WorkflowError(
         "A step can not be run inside another step." +
-        ` Tried to run '${stepInfo.stepName}' inside '${this.executingStep}'`
+          ` Tried to run '${stepInfo.stepName}' inside '${this.executingStep}'`
       );
     }
 
@@ -173,7 +173,7 @@ export class AutoExecutor {
       // user has added/removed a parallel step
       throw new WorkflowError(
         `Incompatible number of parallel steps when call state was '${parallelCallState}'.` +
-        ` Expected ${parallelSteps.length}, got ${plannedParallelStepCount} from the request.`
+          ` Expected ${parallelSteps.length}, got ${plannedParallelStepCount} from the request.`
       );
     }
 
@@ -193,7 +193,7 @@ export class AutoExecutor {
           initialStepCount,
           invokeCount: this.invokeCount,
           telemetry: this.telemetry,
-          debug: this.debug
+          debug: this.debug,
         });
         break;
       }
@@ -208,7 +208,7 @@ export class AutoExecutor {
         if (!planStep || planStep.targetStep === undefined) {
           throw new WorkflowError(
             `There must be a last step and it should have targetStep larger than 0.` +
-            `Received: ${JSON.stringify(planStep)}`
+              `Received: ${JSON.stringify(planStep)}`
           );
         }
         const stepIndex = planStep.targetStep - initialStepCount;
@@ -384,14 +384,14 @@ const validateStep = (lazyStep: BaseLazyStep, stepFromRequest: Step): void => {
   if (lazyStep.stepName !== stepFromRequest.stepName) {
     throw new WorkflowError(
       `Incompatible step name. Expected '${lazyStep.stepName}',` +
-      ` got '${stepFromRequest.stepName}' from the request`
+        ` got '${stepFromRequest.stepName}' from the request`
     );
   }
   // check type name
   if (lazyStep.stepType !== stepFromRequest.stepType) {
     throw new WorkflowError(
       `Incompatible step type. Expected '${lazyStep.stepType}',` +
-      ` got '${stepFromRequest.stepType}' from the request`
+        ` got '${stepFromRequest.stepType}' from the request`
     );
   }
 };
@@ -419,10 +419,10 @@ const validateParallelSteps = (lazySteps: BaseLazyStep[], stepsFromRequest: Step
       const requestStepTypes = stepsFromRequest.map((step) => step.stepType);
       throw new WorkflowError(
         `Incompatible steps detected in parallel execution: ${error.message}` +
-        `\n  > Step Names from the request: ${JSON.stringify(requestStepNames)}` +
-        `\n    Step Types from the request: ${JSON.stringify(requestStepTypes)}` +
-        `\n  > Step Names expected: ${JSON.stringify(lazyStepNames)}` +
-        `\n    Step Types expected: ${JSON.stringify(lazyStepTypes)}`
+          `\n  > Step Names from the request: ${JSON.stringify(requestStepNames)}` +
+          `\n    Step Types from the request: ${JSON.stringify(requestStepTypes)}` +
+          `\n  > Step Names expected: ${JSON.stringify(lazyStepNames)}` +
+          `\n    Step Types expected: ${JSON.stringify(lazyStepTypes)}`
       );
     }
     throw error;

--- a/src/context/steps.ts
+++ b/src/context/steps.ts
@@ -151,14 +151,14 @@ export abstract class BaseLazyStep<TResult = unknown> {
   }
 
   async submitStep({ context, body, headers }: SubmitStepParams) {
-    return await context.qstashClient.batch([
+    return (await context.qstashClient.batch([
       {
         body,
         headers,
         method: "POST",
         url: context.url,
       },
-    ]) as { messageId: string }[];
+    ])) as { messageId: string }[];
   }
 }
 
@@ -236,7 +236,7 @@ export class LazySleepStep extends BaseLazyStep {
   }
 
   async submitStep({ context, body, headers, isParallel }: SubmitStepParams) {
-    return await context.qstashClient.batch([
+    return (await context.qstashClient.batch([
       {
         body,
         headers,
@@ -244,7 +244,7 @@ export class LazySleepStep extends BaseLazyStep {
         url: context.url,
         delay: isParallel ? undefined : this.sleep,
       },
-    ]) as { messageId: string }[]
+    ])) as { messageId: string }[];
   }
 }
 
@@ -287,7 +287,7 @@ export class LazySleepUntilStep extends BaseLazyStep {
   }
 
   async submitStep({ context, body, headers, isParallel }: SubmitStepParams) {
-    return await context.qstashClient.batch([
+    return (await context.qstashClient.batch([
       {
         body,
         headers,
@@ -295,7 +295,7 @@ export class LazySleepUntilStep extends BaseLazyStep {
         url: context.url,
         notBefore: isParallel ? undefined : this.sleepUntil,
       },
-    ]) as { messageId: string }[];
+    ])) as { messageId: string }[];
   }
 }
 
@@ -463,14 +463,14 @@ export class LazyCallStep<TResult = unknown, TBody = unknown> extends BaseLazySt
   }
 
   async submitStep({ context, headers }: SubmitStepParams) {
-    return await context.qstashClient.batch([
+    return (await context.qstashClient.batch([
       {
         headers,
         body: JSON.stringify(this.body),
         method: this.method,
         url: this.url,
       },
-    ]) as { messageId: string }[];
+    ])) as { messageId: string }[];
   }
 }
 
@@ -538,11 +538,11 @@ export class LazyWaitForEventStep extends BaseLazyStep<WaitStepResponse> {
       // to include telemetry headers:
       ...(telemetry
         ? Object.fromEntries(
-          Object.entries(getTelemetryHeaders(telemetry)).map(([header, value]) => [
-            header,
-            [value],
-          ])
-        )
+            Object.entries(getTelemetryHeaders(telemetry)).map(([header, value]) => [
+              header,
+              [value],
+            ])
+          )
         : {}),
 
       // note: using WORKFLOW_ID_HEADER doesn't work, because Runid -> RunId:
@@ -571,14 +571,14 @@ export class LazyWaitForEventStep extends BaseLazyStep<WaitStepResponse> {
   }
 
   async submitStep({ context, body, headers }: SubmitStepParams) {
-    const result = await context.qstashClient.http.request({
+    const result = (await context.qstashClient.http.request({
       path: ["v2", "wait", this.eventId],
       body: body,
       headers,
       method: "POST",
       parseResponseAsJson: false,
-    }) as { messageId: string };
-    return [result]
+    })) as { messageId: string };
+    return [result];
   }
 }
 
@@ -748,12 +748,12 @@ export class LazyInvokeStep<TResult = unknown, TBody = unknown> extends BaseLazy
 
   async submitStep({ context, body, headers }: SubmitStepParams) {
     const newUrl = context.url.replace(/[^/]+$/, this.workflowId);
-    const result = await context.qstashClient.publish({
+    const result = (await context.qstashClient.publish({
       headers,
       method: "POST",
       body,
       url: newUrl,
-    }) as { messageId: string };
+    })) as { messageId: string };
     return [result];
   }
 }

--- a/src/qstash/submit-steps.ts
+++ b/src/qstash/submit-steps.ts
@@ -30,7 +30,7 @@ export const submitParallelSteps = async ({
     steps: planSteps,
   });
 
-  const result = await context.qstashClient.batch(
+  const result = (await context.qstashClient.batch(
     planSteps.map((planStep) => {
       const { headers } = getHeaders({
         initHeaderValue: "false",
@@ -55,7 +55,7 @@ export const submitParallelSteps = async ({
         delay: planStep.sleepFor,
       };
     })
-  ) as { messageId: string }[];
+  )) as { messageId: string }[];
 
   await debug?.log("INFO", "SUBMIT_STEP", {
     messageIds: result.map((message) => {
@@ -64,7 +64,6 @@ export const submitParallelSteps = async ({
       };
     }),
   });
-
 
   throw new WorkflowAbort(planSteps[0].stepName, planSteps[0]);
 };


### PR DESCRIPTION
Adds a way to pass context.call settings when defining an agent:

```ts
const model = context.agents.openai("gpt-3.5-turbo", {
  callSettings: {
    flowControl: {
      key: flowControlKey,
      parallelism: 2,
    },
    retries: 5,
    timeout: 10,
  },
});
```