### PR TITLE
Use process.env if context.env isn't defined in hono

### DIFF
--- a/platforms/hono.ts
+++ b/platforms/hono.ts
@@ -37,7 +37,11 @@ export const serve = <
   options?: PublicServeOptions<TInitialPayload>
 ): ((context: Context<{ Bindings: TBindings; Variables: TVariables }>) => Promise<Response>) => {
   const handler = async (context: Context<{ Bindings: TBindings; Variables: TVariables }>) => {
-    const environment = context.env;
+    const environment = context.env
+      ? context.env
+      : typeof process === "undefined"
+        ? ({} as Record<string, string>)
+        : process.env;
     const request = context.req.raw;
 
     const { handler: serveHandler } = serveBase(routeFunction, telemetry, {


### PR DESCRIPTION
It looks like context.env is only defined in Cloudflare Workers. https://hono.dev/docs/api/context#env

When the serve method from hono is used in vercel, context.env is undefined which causes an error.

Fixed the issue by checking if context.env is defined and falling back to process.env if it isn't.

Fixes: https://github.com/upstash/workflow-js/issues/91