### PR TITLE
Fix: Add warning for non-string step names

### DIFF
--- a/src/context/steps.test.ts
+++ b/src/context/steps.test.ts
@@ -326,11 +326,7 @@ describe("test steps", () => {
     test("should throw when step name isn't string", () => {
       // @ts-expect-error passing number for test purposes
       const throws = () => new LazyFunctionStep(1, () => {});
-      expect(throws).toThrow(
-        new WorkflowError(
-          "A workflow step name must be a string."
-        )
-      );
+      expect(throws).toThrow(new WorkflowError("A workflow step name must be a string."));
     });
   });
 });

--- a/src/context/steps.test.ts
+++ b/src/context/steps.test.ts
@@ -304,7 +304,7 @@ describe("test steps", () => {
   });
 
   describe("stepName check", () => {
-    test("should throw when step name is undefined ", () => {
+    test("should throw when step name is undefined", () => {
       // @ts-expect-error allow undefined for test purposes
       const throws = () => new LazySleepStep(undefined, 10);
       expect(throws).toThrow(
@@ -314,11 +314,21 @@ describe("test steps", () => {
       );
     });
 
-    test("should throw when step name is empty string ", () => {
+    test("should throw when step name is empty string", () => {
       const throws = () => new LazyFunctionStep("", () => {});
       expect(throws).toThrow(
         new WorkflowError(
           "A workflow step name cannot be undefined or an empty string. Please provide a name for your workflow step."
+        )
+      );
+    });
+
+    test("should throw when step name isn't string", () => {
+      // @ts-expect-error passing number for test purposes
+      const throws = () => new LazyFunctionStep(1, () => {});
+      expect(throws).toThrow(
+        new WorkflowError(
+          "A workflow step name must be a string."
         )
       );
     });

--- a/src/context/steps.test.ts
+++ b/src/context/steps.test.ts
@@ -323,7 +323,8 @@ describe("test steps", () => {
       );
     });
 
-    test("should throw when step name isn't string", () => {
+    // will be enabled when the string check in BaseLazyStep constructor is updated
+    test.skip("should throw when step name isn't string", () => {
       // @ts-expect-error passing number for test purposes
       const throws = () => new LazyFunctionStep(1, () => {});
       expect(throws).toThrow(new WorkflowError("A workflow step name must be a string."));

--- a/src/context/steps.ts
+++ b/src/context/steps.ts
@@ -47,6 +47,9 @@ export abstract class BaseLazyStep<TResult = unknown> {
         "A workflow step name cannot be undefined or an empty string. Please provide a name for your workflow step."
       );
     }
+    if (typeof stepName !== "string") {
+      throw new WorkflowError("A workflow step name must be a string.");
+    }
     this.stepName = stepName;
   }
 

--- a/src/context/steps.ts
+++ b/src/context/steps.ts
@@ -48,7 +48,12 @@ export abstract class BaseLazyStep<TResult = unknown> {
       );
     }
     if (typeof stepName !== "string") {
-      throw new WorkflowError("A workflow step name must be a string.");
+      // when updating this warning as error, don't forget to enable to corresponding test
+      // in steps.test.ts. If possible, should be changed together with other deprecations
+      // if a major version is released
+      console.warn(
+        "Workflow Warning: A workflow step name must be a string. In a future release, this will throw an error."
+      );
     }
     this.stepName = stepName;
   }


### PR DESCRIPTION
We were planning to throw initially. But that's a breaking change. Should be done in a major release or when we are certain that no-one is encountering this error.