### PR TITLE
DX-1902: Check for includes instead of exact match in isText

### DIFF
--- a/src/context/steps.ts
+++ b/src/context/steps.ts
@@ -393,7 +393,7 @@ export class LazyCallStep<TResult = unknown, TBody = unknown> extends BaseLazySt
     }
   }
 
-  private static applicationHeaders = new Set([
+  private static applicationContentTypes = [
     "application/json",
     "application/xml",
     "application/javascript",
@@ -402,13 +402,13 @@ export class LazyCallStep<TResult = unknown, TBody = unknown> extends BaseLazySt
     "application/ld+json",
     "application/rss+xml",
     "application/atom+xml",
-  ]);
+  ];
 
   private static isText = (contentTypeHeader: string | null) => {
     if (!contentTypeHeader) {
       return false;
     }
-    if (LazyCallStep.applicationHeaders.has(contentTypeHeader)) {
+    if (LazyCallStep.applicationContentTypes.some((type) => contentTypeHeader.includes(type))) {
       return true;
     }
     if (contentTypeHeader.startsWith("text/")) {

--- a/src/serve/serve.test.ts
+++ b/src/serve/serve.test.ts
@@ -1020,7 +1020,9 @@ describe("serve", () => {
     qstashClient.batch = jest
       .fn()
       .mockReturnValue([{ deduplicatedId: false, messageId: "some-message-id" }]);
-    qstashClient.publish = jest.fn({ deduplicatedId: false, messageId: "some-message-id" });
+    qstashClient.publish = jest
+      .fn()
+      .mockReturnValue({ deduplicatedId: false, messageId: "some-message-id" });
     const client = new WorkflowClient({ token: process.env.QSTASH_TOKEN! });
 
     test("allow http://", async () => {


### PR DESCRIPTION
We checked for exact match for "application/json" etc in the response headers of a context.call. If we determine that the response is text, we try to parse it.

Rerank endpoint of resend responded with application/json; charset=utf-8, which meant that we don't parse the body, resulting in this issue https://github.com/upstash/workflow-js/issues/93

Fixes https://github.com/upstash/workflow-js/issues/93