### PR TITLE
trigger workflows in batches

### DIFF
--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -214,24 +214,115 @@ describe("workflow client", () => {
       },
       responseFields: {
         status: 200,
-        body: "msgId",
+        body: [{ messageId: "msgId" }],
       },
       receivesRequest: {
         method: "POST",
-        url: `${MOCK_QSTASH_SERVER_URL}/v2/publish/${WORKFLOW_ENDPOINT}`,
+        url: `${MOCK_QSTASH_SERVER_URL}/v2/batch`,
         token,
-        body,
-        headers: {
-          "upstash-forward-upstash-workflow-sdk-version": "1",
-          "upstash-forward-user-header": "user-header-value",
-          "upstash-method": "POST",
-          "upstash-retries": "15",
-          "upstash-workflow-init": "true",
-          "upstash-workflow-runid": `wfr_${myWorkflowRunId}`,
-          "upstash-workflow-url": "https://requestcatcher.com/api",
-          "upstash-delay": "1s",
-          "upstash-failure-callback": null,
-        },
+        body: [
+          {
+            destination: WORKFLOW_ENDPOINT,
+            headers: {
+              "upstash-forward-upstash-workflow-sdk-version": "1",
+              "upstash-forward-user-header": "user-header-value",
+              "upstash-method": "POST",
+              "upstash-retries": "15",
+              "upstash-workflow-init": "true",
+              "upstash-workflow-runid": `wfr_${myWorkflowRunId}`,
+              "upstash-workflow-url": "https://requestcatcher.com/api",
+              "upstash-delay": "1s",
+              "content-type": "application/json",
+              "upstash-feature-set": "LazyFetch,InitialBody",
+              "upstash-telemetry-runtime": expect.stringMatching(/bun@/),
+              "upstash-telemetry-sdk": expect.stringMatching(/upstash-qstash-js@/),
+              "upstash-workflow-sdk-version": "1",
+            },
+            body,
+          },
+        ],
+      },
+    });
+  });
+
+  test("should trigger multiple workflow runs", async () => {
+    const myWorkflowRunId = `mock-${getWorkflowRunId()}`;
+    const myWorkflowRunId2 = `mock-${getWorkflowRunId()}`;
+    const body = "request-body";
+    const body2 = "request-body-2";
+    await mockQStashServer({
+      execute: async () => {
+        const result = await client.trigger([
+          {
+            url: WORKFLOW_ENDPOINT,
+            body,
+            headers: { "user-header": "user-header-value" },
+            workflowRunId: myWorkflowRunId,
+            retries: 15,
+            delay: 1,
+          },
+          {
+            url: WORKFLOW_ENDPOINT,
+            body: body2,
+            headers: { "user-header": "user-header-value" },
+            workflowRunId: myWorkflowRunId2,
+            retries: 15,
+            delay: 1,
+          },
+        ]);
+        expect(result).toEqual([
+          { workflowRunId: `wfr_${myWorkflowRunId}` },
+          { workflowRunId: `wfr_${myWorkflowRunId2}` },
+        ]);
+      },
+      responseFields: {
+        status: 200,
+        body: [{ messageId: "msgId" }],
+      },
+      receivesRequest: {
+        method: "POST",
+        url: `${MOCK_QSTASH_SERVER_URL}/v2/batch`,
+        token,
+        body: [
+          {
+            destination: WORKFLOW_ENDPOINT,
+            headers: {
+              "upstash-forward-upstash-workflow-sdk-version": "1",
+              "upstash-forward-user-header": "user-header-value",
+              "upstash-method": "POST",
+              "upstash-retries": "15",
+              "upstash-workflow-init": "true",
+              "upstash-workflow-runid": `wfr_${myWorkflowRunId}`,
+              "upstash-workflow-url": "https://requestcatcher.com/api",
+              "upstash-delay": "1s",
+              "content-type": "application/json",
+              "upstash-feature-set": "LazyFetch,InitialBody",
+              "upstash-telemetry-runtime": expect.stringMatching(/bun@/),
+              "upstash-telemetry-sdk": expect.stringMatching(/upstash-qstash-js@/),
+              "upstash-workflow-sdk-version": "1",
+            },
+            body,
+          },
+          {
+            destination: WORKFLOW_ENDPOINT,
+            headers: {
+              "upstash-forward-upstash-workflow-sdk-version": "1",
+              "upstash-forward-user-header": "user-header-value",
+              "upstash-method": "POST",
+              "upstash-retries": "15",
+              "upstash-workflow-init": "true",
+              "upstash-workflow-runid": `wfr_${myWorkflowRunId2}`,
+              "upstash-workflow-url": "https://requestcatcher.com/api",
+              "upstash-delay": "1s",
+              "content-type": "application/json",
+              "upstash-feature-set": "LazyFetch,InitialBody",
+              "upstash-telemetry-runtime": expect.stringMatching(/bun@/),
+              "upstash-telemetry-sdk": expect.stringMatching(/upstash-qstash-js@/),
+              "upstash-workflow-sdk-version": "1",
+            },
+            body: body2,
+          },
+        ],
       },
     });
   });
@@ -253,24 +344,43 @@ describe("workflow client", () => {
       },
       responseFields: {
         status: 200,
-        body: "msgId",
+        body: [{ messageId: "msgId" }],
       },
       receivesRequest: {
         method: "POST",
-        url: `${MOCK_QSTASH_SERVER_URL}/v2/publish/${WORKFLOW_ENDPOINT}`,
+        url: `${MOCK_QSTASH_SERVER_URL}/v2/batch`,
         token,
-        body,
-        headers: {
-          "upstash-forward-upstash-workflow-sdk-version": "1",
-          "upstash-forward-user-header": "user-header-value",
-          "upstash-method": "POST",
-          "upstash-retries": "15",
-          "upstash-workflow-init": "true",
-          "upstash-workflow-runid": `wfr_${myWorkflowRunId}`,
-          "upstash-workflow-url": "https://requestcatcher.com/api",
-          "upstash-delay": "1s",
-          "upstash-failure-callback": "https://requestcatcher.com/api",
-        },
+        body: [
+          {
+            destination: WORKFLOW_ENDPOINT,
+            headers: {
+              "upstash-forward-upstash-workflow-sdk-version": "1",
+              "upstash-forward-user-header": "user-header-value",
+              "upstash-method": "POST",
+              "upstash-retries": "15",
+              "upstash-workflow-init": "true",
+              "upstash-workflow-runid": `wfr_${myWorkflowRunId}`,
+              "upstash-workflow-url": "https://requestcatcher.com/api",
+              "upstash-delay": "1s",
+              "upstash-failure-callback": "https://requestcatcher.com/api",
+              "content-type": "application/json",
+              "upstash-feature-set": "LazyFetch,InitialBody",
+              "upstash-failure-callback-feature-set": "LazyFetch,InitialBody",
+              "upstash-failure-callback-forward-upstash-workflow-failure-callback": "true",
+              "upstash-failure-callback-forward-upstash-workflow-is-failure": "true",
+              "upstash-failure-callback-forward-user-header": "user-header-value",
+              "upstash-failure-callback-retries": "15",
+              "upstash-failure-callback-workflow-calltype": "failureCall",
+              "upstash-failure-callback-workflow-init": "false",
+              "upstash-failure-callback-workflow-runid": `wfr_${myWorkflowRunId}`,
+              "upstash-failure-callback-workflow-url": "https://requestcatcher.com/api",
+              "upstash-telemetry-runtime": expect.stringMatching(/bun@/),
+              "upstash-telemetry-sdk": expect.stringMatching(/upstash-qstash-js@/),
+              "upstash-workflow-sdk-version": "1",
+            },
+            body,
+          },
+        ],
       },
     });
   });
@@ -292,24 +402,43 @@ describe("workflow client", () => {
       },
       responseFields: {
         status: 200,
-        body: "msgId",
+        body: [{ messageId: "msgId" }],
       },
       receivesRequest: {
         method: "POST",
-        url: `${MOCK_QSTASH_SERVER_URL}/v2/publish/${WORKFLOW_ENDPOINT}`,
+        url: `${MOCK_QSTASH_SERVER_URL}/v2/batch`,
         token,
-        body,
-        headers: {
-          "upstash-forward-upstash-workflow-sdk-version": "1",
-          "upstash-forward-user-header": "user-header-value",
-          "upstash-method": "POST",
-          "upstash-retries": "15",
-          "upstash-workflow-init": "true",
-          "upstash-workflow-runid": `wfr_${myWorkflowRunId}`,
-          "upstash-workflow-url": "https://requestcatcher.com/api",
-          "upstash-delay": "1s",
-          "upstash-failure-callback": "https://requestcatcher.com/some-failure-callback",
-        },
+        body: [
+          {
+            destination: WORKFLOW_ENDPOINT,
+            headers: {
+              "upstash-forward-upstash-workflow-sdk-version": "1",
+              "upstash-forward-user-header": "user-header-value",
+              "upstash-method": "POST",
+              "upstash-retries": "15",
+              "upstash-workflow-init": "true",
+              "upstash-workflow-runid": `wfr_${myWorkflowRunId}`,
+              "upstash-workflow-url": "https://requestcatcher.com/api",
+              "upstash-delay": "1s",
+              "upstash-failure-callback": "https://requestcatcher.com/some-failure-callback",
+              "content-type": "application/json",
+              "upstash-feature-set": "LazyFetch,InitialBody",
+              "upstash-failure-callback-feature-set": "LazyFetch,InitialBody",
+              "upstash-failure-callback-forward-upstash-workflow-failure-callback": "true",
+              "upstash-failure-callback-forward-upstash-workflow-is-failure": "true",
+              "upstash-failure-callback-forward-user-header": "user-header-value",
+              "upstash-failure-callback-retries": "15",
+              "upstash-failure-callback-workflow-calltype": "failureCall",
+              "upstash-failure-callback-workflow-init": "false",
+              "upstash-failure-callback-workflow-runid": `wfr_${myWorkflowRunId}`,
+              "upstash-failure-callback-workflow-url": "https://requestcatcher.com/api",
+              "upstash-telemetry-runtime": expect.stringMatching(/bun@/),
+              "upstash-telemetry-sdk": expect.stringMatching(/upstash-qstash-js@/),
+              "upstash-workflow-sdk-version": "1",
+            },
+            body,
+          },
+        ],
       },
     });
   });

--- a/src/receiver.test.ts
+++ b/src/receiver.test.ts
@@ -196,12 +196,34 @@ describe("receiver", () => {
           const response = await endpoint(requestWithHeader);
           expect(response.status).toBe(200);
         },
-        responseFields: { body: "msgId", status: 200 },
+        responseFields: { body: [{ messageId: "msgId" }], status: 200 },
         receivesRequest: {
           method: "POST",
-          url: `${MOCK_QSTASH_SERVER_URL}/v2/publish/${WORKFLOW_ENDPOINT}`,
+          url: `${MOCK_QSTASH_SERVER_URL}/v2/batch`,
           token,
-          body,
+          body: [
+            {
+              destination: WORKFLOW_ENDPOINT,
+              headers: {
+                "content-type": "application/json",
+                "upstash-feature-set": "LazyFetch,InitialBody",
+                "upstash-forward-authorization": expect.stringMatching(/Bearer /),
+                "upstash-forward-upstash-signature": expect.any(String),
+                "upstash-forward-upstash-workflow-sdk-version": "1",
+                "upstash-method": "POST",
+                "upstash-telemetry-framework": "unknown",
+                "upstash-telemetry-runtime": expect.stringMatching(/unknown, bun@/),
+                "upstash-telemetry-sdk": expect.stringMatching(
+                  /@upstash\/workflow@.*upstash-qstash-js@/
+                ),
+                "upstash-workflow-init": "true",
+                "upstash-workflow-runid": expect.any(String),
+                "upstash-workflow-sdk-version": "1",
+                "upstash-workflow-url": WORKFLOW_ENDPOINT,
+              },
+              body: JSON.stringify(body),
+            },
+          ],
         },
       });
       expect(called).toBeTrue();

--- a/src/serve/serve.test.ts
+++ b/src/serve/serve.test.ts
@@ -65,20 +65,33 @@ describe("serve", () => {
         const response = await endpoint(request);
         expect(response.status).toBe(200);
       },
-      responseFields: { body: "msgId", status: 200 },
+      responseFields: { body: [{ messageId: "msgId" }], status: 200 },
       receivesRequest: {
         method: "POST",
-        url: `${MOCK_QSTASH_SERVER_URL}/v2/publish/${WORKFLOW_ENDPOINT}`,
+        url: `${MOCK_QSTASH_SERVER_URL}/v2/batch`,
         token,
-        body: initialPayload,
-        headers: {
-          [WORKFLOW_INIT_HEADER]: "true",
-          [WORKFLOW_PROTOCOL_VERSION_HEADER]: "1",
-          [`Upstash-Forward-${WORKFLOW_PROTOCOL_VERSION_HEADER}`]: "1",
-          "upstash-retries": "1",
-          "Upstash-Flow-Control-Key": "my-key",
-          "Upstash-Flow-Control-Value": "parallelism=1",
-        },
+        body: [
+          {
+            destination: WORKFLOW_ENDPOINT,
+            headers: {
+              "content-type": "application/json",
+              "upstash-feature-set": "LazyFetch,InitialBody",
+              "upstash-flow-control-key": "my-key",
+              "upstash-flow-control-value": "parallelism=1",
+              "upstash-forward-upstash-workflow-sdk-version": "1",
+              "upstash-method": "POST",
+              "upstash-retries": "1",
+              "upstash-telemetry-framework": "unknown",
+              "upstash-telemetry-runtime": "unknown",
+              "upstash-telemetry-sdk": "@upstash/workflow@v0.2.13",
+              "upstash-workflow-init": "true",
+              "upstash-workflow-runid": expect.stringMatching(/^wfr_/),
+              "upstash-workflow-sdk-version": "1",
+              "upstash-workflow-url": WORKFLOW_ENDPOINT,
+            },
+            body: initialPayload,
+          },
+        ],
       },
     });
   });
@@ -148,25 +161,32 @@ describe("serve", () => {
         {
           stepsToAdd: [],
           responseFields: {
-            body: { messageId: "some-message-id" },
+            body: [{ messageId: "some-message-id" }],
             status: 200,
           },
           receivesRequest: {
             method: "POST",
-            url: `${MOCK_QSTASH_SERVER_URL}/v2/publish/https://requestcatcher.com/api`,
+            url: `${MOCK_QSTASH_SERVER_URL}/v2/batch`,
             token,
-            body: initialPayload,
-            headers: {
-              "upstash-workflow-sdk-version": "1",
-              "upstash-feature-set": "LazyFetch,InitialBody",
-              "upstash-forward-upstash-workflow-sdk-version": "1",
-              "upstash-forward-upstash-workflow-invoke-count": "2",
-              "upstash-method": "POST",
-              "upstash-workflow-init": "true",
-              "upstash-workflow-url": WORKFLOW_ENDPOINT,
-              "upstash-flow-control-key": "my-key",
-              "upstash-flow-control-value": "rate=3",
-            },
+            body: [
+              {
+                destination: WORKFLOW_ENDPOINT,
+                headers: {
+                  "upstash-workflow-sdk-version": "1",
+                  "content-type": "application/json",
+                  "upstash-feature-set": "LazyFetch,InitialBody",
+                  "upstash-forward-upstash-workflow-sdk-version": "1",
+                  "upstash-forward-upstash-workflow-invoke-count": "2",
+                  "upstash-method": "POST",
+                  "upstash-workflow-init": "true",
+                  "upstash-workflow-url": WORKFLOW_ENDPOINT,
+                  "upstash-flow-control-key": "my-key",
+                  "upstash-flow-control-value": "rate=3",
+                  "upstash-workflow-runid": expect.stringMatching(/^wfr/),
+                },
+                body: initialPayload,
+              },
+            ],
           },
         },
         {

--- a/src/workflow-requests.test.ts
+++ b/src/workflow-requests.test.ts
@@ -56,20 +56,32 @@ describe("Workflow Requests", () => {
         expect(result.isOk()).toBeTrue();
       },
       responseFields: {
-        body: { messageId: "msgId" },
+        body: [{ messageId: "msgId" }],
         status: 200,
       },
       receivesRequest: {
         method: "POST",
-        url: `${MOCK_QSTASH_SERVER_URL}/v2/publish/https://requestcatcher.com/api`,
+        url: `${MOCK_QSTASH_SERVER_URL}/v2/batch`,
         token,
-        body: initialPayload,
-        headers: {
-          "upstash-retries": "0",
-          "Upstash-Workflow-Init": "true",
-          "Upstash-Workflow-RunId": workflowRunId,
-          "Upstash-Workflow-Url": WORKFLOW_ENDPOINT,
-        },
+        body: [
+          {
+            destination: WORKFLOW_ENDPOINT,
+            headers: {
+              "content-type": "application/json",
+              "upstash-feature-set": "LazyFetch,InitialBody",
+              "upstash-forward-upstash-workflow-sdk-version": "1",
+              "upstash-method": "POST",
+              "upstash-retries": "0",
+              "upstash-telemetry-runtime": expect.stringMatching(/bun@/),
+              "upstash-telemetry-sdk": expect.stringMatching(/upstash-qstash-js@/),
+              "upstash-workflow-init": "true",
+              "upstash-workflow-runid": workflowRunId,
+              "upstash-workflow-sdk-version": "1",
+              "upstash-workflow-url": WORKFLOW_ENDPOINT,
+            },
+            body: initialPayload,
+          },
+        ],
       },
     });
   });

--- a/src/workflow-requests.ts
+++ b/src/workflow-requests.ts
@@ -20,79 +20,103 @@ import type {
 } from "./types";
 import { StepTypes } from "./types";
 import type { WorkflowLogger } from "./logger";
-import { FlowControl, PublishRequest, QstashError } from "@upstash/qstash";
+import { FlowControl, PublishBatchRequest, PublishRequest, QstashError } from "@upstash/qstash";
 import { getSteps } from "./client/utils";
 import { getHeaders } from "./qstash/headers";
+import { PublishToUrlResponse } from "@upstash/qstash";
 
-export const triggerFirstInvocation = async <TInitialPayload>({
-  workflowContext,
-  useJSONContent,
-  telemetry,
-  debug,
-  invokeCount,
-  delay,
-}: {
+type TriggerFirstInvocationParams<TInitialPayload> = {
   workflowContext: WorkflowContext<TInitialPayload>;
   useJSONContent?: boolean;
   telemetry?: Telemetry;
   debug?: WorkflowLogger;
   invokeCount?: number;
   delay?: PublishRequest["delay"];
-}): Promise<Ok<"success" | "workflow-run-already-exists", never> | Err<never, Error>> => {
-  const { headers } = getHeaders({
-    initHeaderValue: "true",
-    workflowConfig: {
-      workflowRunId: workflowContext.workflowRunId,
-      workflowUrl: workflowContext.url,
-      failureUrl: workflowContext.failureUrl,
-      retries: workflowContext.retries,
-      telemetry,
-      flowControl: workflowContext.flowControl,
-      useJSONContent: useJSONContent ?? false,
-    },
-    invokeCount: invokeCount ?? 0,
-    userHeaders: workflowContext.headers,
-  });
+};
 
-  // QStash doesn't forward content-type when passed in `upstash-forward-content-type`
-  // so we need to pass it in the headers
-  if (workflowContext.headers.get("content-type")) {
-    headers["content-type"] = workflowContext.headers.get("content-type")!;
-  }
+export const triggerFirstInvocation = async <TInitialPayload>(
+  params:
+    | TriggerFirstInvocationParams<TInitialPayload>
+    | TriggerFirstInvocationParams<TInitialPayload>[]
+): Promise<Ok<"success" | "workflow-run-already-exists", never> | Err<never, Error>> => {
+  const firstInvocationParams = Array.isArray(params) ? params : [params];
+  const workflowContextClient = firstInvocationParams[0].workflowContext.qstashClient;
 
-  if (useJSONContent) {
-    headers["content-type"] = "application/json";
-  }
+  const invocationBatch = firstInvocationParams.map((invocation) => {
+    const { headers } = getHeaders({
+      initHeaderValue: "true",
+      workflowConfig: {
+        workflowRunId: invocation.workflowContext.workflowRunId,
+        workflowUrl: invocation.workflowContext.url,
+        failureUrl: invocation.workflowContext.failureUrl,
+        retries: invocation.workflowContext.retries,
+        telemetry: invocation.telemetry,
+        flowControl: invocation.workflowContext.flowControl,
+        useJSONContent: invocation.useJSONContent ?? false,
+      },
+      invokeCount: invocation.invokeCount ?? 0,
+      userHeaders: invocation.workflowContext.headers,
+    });
 
-  try {
+    // QStash doesn't forward content-type when passed in `upstash-forward-content-type`
+    // so we need to pass it in the headers
+    if (invocation.workflowContext.headers.get("content-type")) {
+      headers["content-type"] = invocation.workflowContext.headers.get("content-type")!;
+    }
+
+    if (invocation.useJSONContent) {
+      headers["content-type"] = "application/json";
+    }
+
     const body =
-      typeof workflowContext.requestPayload === "string"
-        ? workflowContext.requestPayload
-        : JSON.stringify(workflowContext.requestPayload);
-    const result = await workflowContext.qstashClient.publish({
+      typeof invocation.workflowContext.requestPayload === "string"
+        ? invocation.workflowContext.requestPayload
+        : JSON.stringify(invocation.workflowContext.requestPayload);
+
+    return {
       headers,
       method: "POST",
       body,
-      url: workflowContext.url,
-      delay,
-    });
+      url: invocation.workflowContext.url,
+      delay: invocation.delay,
+    } as PublishBatchRequest;
+  });
 
-    if (result.deduplicated) {
-      await debug?.log("WARN", "SUBMIT_FIRST_INVOCATION", {
-        message: `Workflow run ${workflowContext.workflowRunId} already exists. A new one isn't created.`,
-        headers,
-        requestPayload: workflowContext.requestPayload,
-        url: workflowContext.url,
-        messageId: result.messageId,
-      });
+  try {
+    const results = (await workflowContextClient.batch(invocationBatch)) as PublishToUrlResponse[];
+
+    const invocationStatuses: ("success" | "workflow-run-already-exists")[] = [];
+
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      const invocationParams = firstInvocationParams[i];
+      if (result.deduplicated) {
+        await invocationParams.debug?.log("WARN", "SUBMIT_FIRST_INVOCATION", {
+          message: `Workflow run ${invocationParams.workflowContext.workflowRunId} already exists. A new one isn't created.`,
+          headers: invocationParams.workflowContext.headers,
+          requestPayload: invocationParams.workflowContext.requestPayload,
+          url: invocationParams.workflowContext.url,
+          messageId: result.messageId,
+        });
+        invocationStatuses.push("workflow-run-already-exists");
+      } else {
+        await invocationParams.debug?.log("SUBMIT", "SUBMIT_FIRST_INVOCATION", {
+          headers: invocationParams.workflowContext.headers,
+          requestPayload: invocationParams.workflowContext.requestPayload,
+          url: invocationParams.workflowContext.url,
+          messageId: result.messageId,
+        });
+        invocationStatuses.push("success");
+      }
+    }
+
+    const hasAnyDeduplicated = invocationStatuses.some(
+      (status) => status === "workflow-run-already-exists"
+    );
+
+    if (hasAnyDeduplicated) {
       return ok("workflow-run-already-exists");
     } else {
-      await debug?.log("SUBMIT", "SUBMIT_FIRST_INVOCATION", {
-        headers,
-        requestPayload: workflowContext.requestPayload,
-        url: workflowContext.url,
-        messageId: result.messageId,
-      });
       return ok("success");
     }
   } catch (error) {


### PR DESCRIPTION
Switched the workflow triggers to use batch requests instead of publish requests to allow multiple message sending ability consuming single request.