### PR TITLE
DX-1996: print warning if error in custom auth

### DIFF
--- a/src/context/steps.ts
+++ b/src/context/steps.ts
@@ -510,7 +510,10 @@ export class LazyWaitForEventStep<TEventData> extends BaseLazyStep<WaitStepRespo
     };
   }
 
-  public async getResultStep(concurrent: number, stepId: number): Promise<Step<WaitStepResponse<TEventData>>> {
+  public async getResultStep(
+    concurrent: number,
+    stepId: number
+  ): Promise<Step<WaitStepResponse<TEventData>>> {
     return await Promise.resolve({
       stepId,
       stepName: this.stepName,

--- a/src/serve/authorization.ts
+++ b/src/serve/authorization.ts
@@ -97,6 +97,7 @@ export class DisabledWorkflowContext<
       ) {
         return ok("step-found");
       }
+      console.warn("Upstash Workflow: Received an error while authorizing request. Please avoid throwing errors before the first step of your workflow.");
       return err(error as Error);
     }
 

--- a/src/serve/authorization.ts
+++ b/src/serve/authorization.ts
@@ -97,7 +97,9 @@ export class DisabledWorkflowContext<
       ) {
         return ok("step-found");
       }
-      console.warn("Upstash Workflow: Received an error while authorizing request. Please avoid throwing errors before the first step of your workflow.");
+      console.warn(
+        "Upstash Workflow: Received an error while authorizing request. Please avoid throwing errors before the first step of your workflow."
+      );
       return err(error as Error);
     }
 


### PR DESCRIPTION
The users shouldn't throw errors before the first step.

This will automatically make the auth attempt fail and workflow/failure function etc won't execute.

So we add a warning saying that this was unexpected.