### PR TITLE
Fix: Enhance expect function with ANY_STRING pattern matching and update related tests

### DIFF
--- a/examples/ci/app/ci/utils.test.ts
+++ b/examples/ci/app/ci/utils.test.ts
@@ -1,7 +1,58 @@
 import { test, expect } from "bun:test";
-import { expect as utilsExpect } from "./utils"
+import { expect as utilsExpect, ANY_STRING } from "./utils"
 
-test("expect", () => {
+test("expect - basic equality", () => {
   expect(() => utilsExpect("same", "same")).not.toThrow()
   expect(() => utilsExpect("not", "same")).toThrow(`Unexpected value.\n\tReceived "not"\n\tExpected "same"`)
+})
+
+test("expect - ANY_STRING pattern matching", () => {
+  // Test basic ANY_STRING replacement
+  expect(() => utilsExpect("hello world", `hello ${ANY_STRING}`)).not.toThrow()
+  expect(() => utilsExpect("test123", `test${ANY_STRING}`)).not.toThrow()
+  expect(() => utilsExpect("prefix-suffix", `prefix${ANY_STRING}suffix`)).not.toThrow()
+  
+  // Test multiple ANY_STRING patterns
+  expect(() => utilsExpect(`user-123-data`, `user${ANY_STRING}data`)).not.toThrow()
+  expect(() => utilsExpect("id_abc_def_end", `id${ANY_STRING}end`)).not.toThrow()
+  
+  // Test empty string matching
+  expect(() => utilsExpect("start", `start${ANY_STRING}`)).not.toThrow()
+  expect(() => utilsExpect("end", `${ANY_STRING}end`)).not.toThrow()
+  
+  // Test full string replacement
+  expect(() => utilsExpect("anything", `${ANY_STRING}`)).not.toThrow()
+})
+
+test("expect - ANY_STRING pattern failures", () => {
+  // Should fail when pattern doesn't match
+  expect(() => utilsExpect("hello world", `goodbye ${ANY_STRING}`))
+    .toThrow(`Unexpected value.\n\tReceived "hello world"\n\tExpected pattern "goodbye ${ANY_STRING}"`)
+  
+  expect(() => utilsExpect("test", `testing${ANY_STRING}`))
+    .toThrow(`Unexpected value.\n\tReceived "test"\n\tExpected pattern "testing${ANY_STRING}"`)
+  
+  expect(() => utilsExpect("prefix-wrong", `prefix${ANY_STRING}suffix`))
+    .toThrow(`Unexpected value.\n\tReceived "prefix-wrong"\n\tExpected pattern "prefix${ANY_STRING}suffix"`)
+})
+
+test("expect - non-string types", () => {
+  // Numbers
+  expect(() => utilsExpect(42, 42)).not.toThrow()
+  expect(() => utilsExpect(42, 43)).toThrow(`Unexpected value.\n\tReceived "42"\n\tExpected "43"`)
+  
+  // Booleans
+  expect(() => utilsExpect(true, true)).not.toThrow()
+  expect(() => utilsExpect(true, false)).toThrow(`Unexpected value.\n\tReceived "true"\n\tExpected "false"`)
+  
+  // Null and undefined
+  expect(() => utilsExpect(null, null)).not.toThrow()
+  expect(() => utilsExpect(undefined, undefined)).not.toThrow()
+  expect(() => utilsExpect(null, undefined)).toThrow(`Unexpected value.\n\tReceived "null"\n\tExpected "undefined"`)
+  
+  // Objects
+  const obj1 = { a: 1 }
+  const obj2 = { a: 1 }
+  expect(() => utilsExpect(obj1, obj1)).not.toThrow() // Same reference
+  expect(() => utilsExpect(obj1, obj2)).toThrow() // Different references
 })

--- a/examples/ci/app/ci/utils.ts
+++ b/examples/ci/app/ci/utils.ts
@@ -84,10 +84,26 @@ export const initiateTest = async (route: string) => {
 }
 
 type ExpectType = number | string | object | undefined | void | boolean | null
+
+export const ANY_STRING = '__ANY_STRING_PLACEHOLDER_9d8f7e6c5b4a__'
+
 export const expect = <TObject extends ExpectType = ExpectType>(
   received: TObject,
   expected: TObject
 ) => {
+  // Handle string pattern matching with ANY_STRING
+  if (typeof received === 'string' && typeof expected === 'string') {
+    const expectedStr = expected as string
+    if (expectedStr.includes(ANY_STRING)) {
+      const pattern = expectedStr.replace(new RegExp(ANY_STRING.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'), '.*')
+      const regex = new RegExp(`^${pattern}$`)
+      if (!regex.test(received as string)) {
+        throw new Error(`Unexpected value.\n\tReceived "${received}"\n\tExpected pattern "${expected}"`)
+      }
+      return
+    }
+  }
+
   if (received !== expected) {
     throw new Error(`Unexpected value.\n\tReceived "${received}"\n\tExpected "${expected}"`)
   }

--- a/examples/ci/app/test-routes/auth/custom/workflow/route.ts
+++ b/examples/ci/app/test-routes/auth/custom/workflow/route.ts
@@ -1,6 +1,6 @@
 import { serve } from "@upstash/workflow/nextjs";
 import { BASE_URL, CI_RANDOM_ID_HEADER, CI_ROUTE_HEADER, TEST_ROUTE_PREFIX } from "app/ci/constants";
-import { testServe, expect } from "app/ci/utils";
+import { testServe, expect, ANY_STRING } from "app/ci/utils";
 import { FailureFunctionPayload, WorkflowContext } from "@upstash/workflow";
 import { saveResult } from "app/ci/upstash/redis";
 
@@ -72,7 +72,8 @@ export const { POST, GET } = testServe(
         500,
         {
           error: "WorkflowError",
-          message: "Not authorized to run the failure function."
+          message: "Not authorized to run the failure function.",
+          stack: ANY_STRING
         }
       )
       

--- a/examples/ci/app/test-routes/call/workflow/route.ts
+++ b/examples/ci/app/test-routes/call/workflow/route.ts
@@ -96,7 +96,7 @@ export const { POST, GET } = testServe(
     retries: 0
   }
   ), {
-  expectedCallCount: 14,
+  expectedCallCount: 13,
   expectedResult: "called GET 'third-party-result' 'get-header-value-x'",
   payload,
   headers: {

--- a/examples/ci/app/test-routes/failureUrl/third-party/route.ts
+++ b/examples/ci/app/test-routes/failureUrl/third-party/route.ts
@@ -1,6 +1,6 @@
 import { CI_RANDOM_ID_HEADER, CI_ROUTE_HEADER } from "app/ci/constants"
 import { saveResultsWithoutContext } from "app/ci/upstash/redis"
-import { expect } from "app/ci/utils"
+import { ANY_STRING, expect } from "app/ci/utils"
 import { ERROR_MESSAGE, HEADER, HEADER_VALUE } from "../constants"
 
 export const POST = async (request: Request) => {
@@ -11,7 +11,7 @@ export const POST = async (request: Request) => {
   }
 
   const errorMessage = atob(result.body)
-  expect(errorMessage, `{"error":"Error","message":"${ERROR_MESSAGE}"}`)
+  expect(errorMessage, `{"error":"Error","message":"${ERROR_MESSAGE}","stack":${ANY_STRING}}`)
   expect(request.headers.get(HEADER), HEADER_VALUE)
 
   // get id and route

--- a/examples/ci/app/test-routes/failureUrl/workflow/route.ts
+++ b/examples/ci/app/test-routes/failureUrl/workflow/route.ts
@@ -1,6 +1,6 @@
 import { serve } from "@upstash/workflow/nextjs";
 import { BASE_URL, TEST_ROUTE_PREFIX } from "app/ci/constants";
-import { testServe, expect } from "app/ci/utils";
+import { testServe, expect, ANY_STRING } from "app/ci/utils";
 import { ERROR_MESSAGE, PAYLOAD, HEADER, HEADER_VALUE } from "../constants";
 
 const thirdPartyEndpoint = `${TEST_ROUTE_PREFIX}/failureUrl/third-party`
@@ -23,7 +23,7 @@ export const { POST, GET } = testServe(
     }
   ), {
     expectedCallCount: 2,
-    expectedResult: `{"error":"Error","message":"${ERROR_MESSAGE}"}`,
+    expectedResult: `{"error":"Error","message":"${ERROR_MESSAGE}","stack":${ANY_STRING}}`,
     payload: PAYLOAD,
     headers: {
       [ HEADER ]: HEADER_VALUE,


### PR DESCRIPTION
Tests check existence of a long stack trace string. Since I don't use expect in bun, we can't the usual expect.any(String), so I wrote my own matcher