### PR TITLE
DX-2194: add keepTriggerConfig option to workflow trigger

### DIFF
--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -278,6 +278,7 @@ describe("workflow client", () => {
             retryDelay: "2000",
             notBefore: new Date("2100-01-01T00:00:00Z").getTime() / 1000,
             useFailureFunction: true,
+            keepTriggerConfig: true,
           },
         ]);
         expect(result).toEqual([
@@ -328,7 +329,7 @@ describe("workflow client", () => {
               "upstash-workflow-url": "https://requestcatcher.com/api",
               "upstash-not-before": "4102444800",
               "content-type": "application/json",
-              "upstash-feature-set": "LazyFetch,InitialBody,WF_DetectTrigger",
+              "upstash-feature-set": "LazyFetch,InitialBody,WF_DetectTrigger,WF_TriggerOnConfig",
               "upstash-telemetry-framework": "unknown",
               "upstash-telemetry-runtime": expect.stringMatching(/bun@/),
               "upstash-telemetry-sdk": expect.stringContaining("@upstash/workflow"),

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -267,6 +267,7 @@ export class Client {
         telemetry: { sdk: SDK_TELEMETRY },
         delay: option.delay,
         notBefore: option.notBefore,
+        keepTriggerConfig: option.keepTriggerConfig,
       };
     });
     const result = await triggerFirstInvocation(invocations);

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -419,6 +419,13 @@ export type TriggerOptions = {
    * Can be used to filter the workflow run logs.
    */
   label?: string;
+  /**
+   * Whether to apply the configuration (flow control,
+   * retries, failure url, retry delay) passed in trigger
+   *
+   * @default false
+   */
+  keepTriggerConfig?: boolean;
 } & (
   | {
       /**

--- a/src/qstash/headers.ts
+++ b/src/qstash/headers.ts
@@ -61,6 +61,7 @@ type WorkflowHeaderParams = {
   invokeCount?: number;
   initHeaderValue: "true" | "false";
   stepInfo?: StepInfo;
+  keepTriggerConfig?: boolean;
 };
 
 class WorkflowHeaders {
@@ -70,6 +71,7 @@ class WorkflowHeaders {
   private initHeaderValue: "true" | "false";
   private stepInfo?: Required<StepInfo>;
   private headers: WorkflowHeaderGroups;
+  private keepTriggerConfig?: boolean;
 
   constructor({
     userHeaders,
@@ -77,6 +79,7 @@ class WorkflowHeaders {
     invokeCount,
     initHeaderValue,
     stepInfo,
+    keepTriggerConfig,
   }: WorkflowHeaderParams) {
     this.userHeaders = userHeaders;
     this.workflowConfig = workflowConfig;
@@ -88,6 +91,7 @@ class WorkflowHeaders {
       workflowHeaders: {},
       failureHeaders: {},
     };
+    this.keepTriggerConfig = keepTriggerConfig;
   }
 
   getHeaders(): HeadersResponse {
@@ -109,7 +113,9 @@ class WorkflowHeaders {
       [WORKFLOW_INIT_HEADER]: this.initHeaderValue,
       [WORKFLOW_ID_HEADER]: this.workflowConfig.workflowRunId,
       [WORKFLOW_URL_HEADER]: this.workflowConfig.workflowUrl,
-      [WORKFLOW_FEATURE_HEADER]: "LazyFetch,InitialBody,WF_DetectTrigger",
+      [WORKFLOW_FEATURE_HEADER]:
+        "LazyFetch,InitialBody,WF_DetectTrigger" +
+        (this.keepTriggerConfig ? ",WF_TriggerOnConfig" : ""),
       [WORKFLOW_PROTOCOL_VERSION_HEADER]: WORKFLOW_PROTOCOL_VERSION,
       ...(this.workflowConfig.telemetry ? getTelemetryHeaders(this.workflowConfig.telemetry) : {}),
       ...(this.workflowConfig.telemetry &&

--- a/src/workflow-requests.ts
+++ b/src/workflow-requests.ts
@@ -34,6 +34,7 @@ type TriggerFirstInvocationParams<TInitialPayload> = {
   invokeCount?: number;
   delay?: PublishRequest["delay"];
   notBefore?: PublishRequest["notBefore"];
+  keepTriggerConfig?: boolean;
 };
 
 export const triggerFirstInvocation = async <TInitialPayload>(
@@ -45,7 +46,15 @@ export const triggerFirstInvocation = async <TInitialPayload>(
   const workflowContextClient = firstInvocationParams[0].workflowContext.qstashClient;
 
   const invocationBatch = firstInvocationParams.map(
-    ({ workflowContext, useJSONContent, telemetry, invokeCount, delay, notBefore }) => {
+    ({
+      workflowContext,
+      useJSONContent,
+      telemetry,
+      invokeCount,
+      delay,
+      notBefore,
+      keepTriggerConfig,
+    }) => {
       const { headers } = getHeaders({
         initHeaderValue: "true",
         workflowConfig: {
@@ -60,6 +69,7 @@ export const triggerFirstInvocation = async <TInitialPayload>(
         },
         invokeCount: invokeCount ?? 0,
         userHeaders: workflowContext.headers,
+        keepTriggerConfig: keepTriggerConfig,
       });
 
       // QStash doesn't forward content-type when passed in `upstash-forward-content-type`


### PR DESCRIPTION
Add keepTriggerConfig to client.trigger:

```ts
const result = await client.trigger(
  {
    url: "...",
    keepTriggerConfig: true,
  },
);
```

The new parameter makes it possible to persist workflow config in the whole workflow, removing the need for setting configs in serve options.