### PR TITLE
example(fastify): Copy headers

### DIFF
--- a/examples/fastify/src/server.ts
+++ b/examples/fastify/src/server.ts
@@ -94,7 +94,9 @@ fastify.register(fastifyEnv, options).after(() => {
 
       // Set status and headers
       reply.code(webResponse.status);
-
+      for (const [key, value] of webResponse.headers) {
+        reply.header(key, value);
+      }
       // Send body
       const responseBody = await webResponse.arrayBuffer();
       reply.send(Buffer.from(responseBody));


### PR DESCRIPTION
I found that the example with fastify doesn't work with qstash dev server due to missing headers.