### PR TITLE
fix: Schema validation breaking workflow callback requests

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ export const WORKFLOW_ID_HEADER = "Upstash-Workflow-RunId";
 export const WORKFLOW_INIT_HEADER = "Upstash-Workflow-Init";
 export const WORKFLOW_URL_HEADER = "Upstash-Workflow-Url";
 export const WORKFLOW_CREATED_AT_HEADER = "Upstash-Workflow-CreatedAt";
+export const WORKFLOW_CALLBACK_HEADER = "Upstash-Workflow-Callback";
 export const WORKFLOW_FAILURE_HEADER = "Upstash-Workflow-Is-Failure";
 export const WORKFLOW_FAILURE_CALLBACK_HEADER = "Upstash-Workflow-Failure-Callback";
 export const WORKFLOW_FEATURE_HEADER = "Upstash-Feature-Set";

--- a/src/serve/index.ts
+++ b/src/serve/index.ts
@@ -2,6 +2,7 @@ import { makeCancelRequest } from "../client/utils";
 import {
   SDK_TELEMETRY,
   WORKFLOW_CREATED_AT_HEADER,
+  WORKFLOW_ID_HEADER,
   WORKFLOW_INVOKE_COUNT_HEADER,
   WORKFLOW_LABEL_HEADER,
   WORKFLOW_PROTOCOL_VERSION,
@@ -148,6 +149,35 @@ export const serveBase = <
       );
     }
 
+    // check if request is a third party call result
+    const callReturnCheck = await handleThirdPartyCallResult({
+      request,
+      requestPayload: rawInitialPayload,
+      client: regionalClient,
+      workflowUrl,
+      telemetry,
+      middlewareManager,
+    });
+    if (callReturnCheck.isErr()) {
+      throw callReturnCheck.error;
+    } else if (callReturnCheck.value === "workflow-ended") {
+      return responseGenerator(
+        createResponseData(request.headers.get(WORKFLOW_ID_HEADER) ?? workflowRunId, {
+          condition: "workflow-already-ended",
+        })
+      );
+    } else if (
+      callReturnCheck.value === "is-call-return" ||
+      callReturnCheck.value === "call-will-retry"
+    ) {
+      // response to QStash in call cases
+      return responseGenerator(
+        createResponseData(request.headers.get(WORKFLOW_ID_HEADER) ?? workflowRunId, {
+          condition: "fromCallback",
+        })
+      );
+    }
+
     // check if the request is a failure callback
     const failureCheck = await handleFailure<TInitialPayload>({
       request,
@@ -225,95 +255,69 @@ export const serveBase = <
       );
     }
 
-    // check if request is a third party call result
-    const callReturnCheck = await handleThirdPartyCallResult({
-      request,
-      requestPayload: rawInitialPayload,
-      client: regionalClient,
-      workflowUrl,
-      telemetry,
-      middlewareManager,
-    });
-    if (callReturnCheck.isErr()) {
-      throw callReturnCheck.error;
-    } else if (callReturnCheck.value === "continue-workflow") {
-      // request is not third party call. Continue workflow as usual
-      const result = isFirstInvocation
-        ? await triggerFirstInvocation({
-            workflowContext,
-            useJSONContent,
-            telemetry,
-            invokeCount,
-            middlewareManager,
-            unknownSdk,
-          })
-        : await triggerRouteFunction({
-            onStep: async () => {
-              if (steps.length === 1) {
-                await middlewareManager.dispatchLifecycle("runStarted", {});
-              }
-              return await routeFunction(workflowContext);
-            },
-            onCleanup: async (result) => {
-              await middlewareManager.dispatchLifecycle("runCompleted", {
-                result,
-              });
-              await triggerWorkflowDelete(
-                workflowContext,
-                result,
-                false,
-                middlewareManager.dispatchDebug.bind(middlewareManager)
-              );
-            },
-            onCancel: async () => {
-              await makeCancelRequest(workflowContext.qstashClient.http, workflowRunId);
-            },
-            middlewareManager,
-          });
-
-      if (result.isOk() && isInstanceOf(result.value, WorkflowNonRetryableError)) {
-        return responseGenerator(
-          createResponseData(workflowRunId, {
-            condition: "non-retryable-error",
-            result: result.value,
-          })
-        );
-      }
-
-      if (result.isOk() && isInstanceOf(result.value, WorkflowRetryAfterError)) {
-        return responseGenerator(
-          createResponseData(workflowRunId, {
-            condition: "retry-after-error",
-            result: result.value,
-          })
-        );
-      }
-
-      if (result.isErr()) {
-        // error while running the workflow or when cleaning up
-        throw result.error;
-      }
-
-      // Returns a Response with `workflowRunId` at the end of each step.
-      await middlewareManager.dispatchDebug("onInfo", {
-        info: `Workflow endpoint execution completed successfully.`,
-      });
-      return responseGenerator(
-        createResponseData(workflowContext.workflowRunId, {
-          condition: "success",
+    const result = isFirstInvocation
+      ? await triggerFirstInvocation({
+          workflowContext,
+          useJSONContent,
+          telemetry,
+          invokeCount,
+          middlewareManager,
+          unknownSdk,
         })
-      );
-    } else if (callReturnCheck.value === "workflow-ended") {
+      : await triggerRouteFunction({
+          onStep: async () => {
+            if (steps.length === 1) {
+              await middlewareManager.dispatchLifecycle("runStarted", {});
+            }
+            return await routeFunction(workflowContext);
+          },
+          onCleanup: async (result) => {
+            await middlewareManager.dispatchLifecycle("runCompleted", {
+              result,
+            });
+            await triggerWorkflowDelete(
+              workflowContext,
+              result,
+              false,
+              middlewareManager.dispatchDebug.bind(middlewareManager)
+            );
+          },
+          onCancel: async () => {
+            await makeCancelRequest(workflowContext.qstashClient.http, workflowRunId);
+          },
+          middlewareManager,
+        });
+
+    if (result.isOk() && isInstanceOf(result.value, WorkflowNonRetryableError)) {
       return responseGenerator(
-        createResponseData(workflowContext.workflowRunId, {
-          condition: "workflow-already-ended",
+        createResponseData(workflowRunId, {
+          condition: "non-retryable-error",
+          result: result.value,
         })
       );
     }
-    // response to QStash in call cases
+
+    if (result.isOk() && isInstanceOf(result.value, WorkflowRetryAfterError)) {
+      return responseGenerator(
+        createResponseData(workflowRunId, {
+          condition: "retry-after-error",
+          result: result.value,
+        })
+      );
+    }
+
+    if (result.isErr()) {
+      // error while running the workflow or when cleaning up
+      throw result.error;
+    }
+
+    // Returns a Response with `workflowRunId` at the end of each step.
+    await middlewareManager.dispatchDebug("onInfo", {
+      info: `Workflow endpoint execution completed successfully.`,
+    });
     return responseGenerator(
       createResponseData(workflowContext.workflowRunId, {
-        condition: "fromCallback",
+        condition: "success",
       })
     );
   };

--- a/src/serve/serve.test.ts
+++ b/src/serve/serve.test.ts
@@ -12,7 +12,13 @@ import {
 import { nanoid } from "../utils";
 import { Client } from "@upstash/qstash";
 import { Client as WorkflowClient } from "../client";
-import type { FinishCondition, RouteFunction, Step, WorkflowServeOptions } from "../types";
+import type {
+  FinishCondition,
+  RouteFunction,
+  Step,
+  WorkflowClient as WorkflowQStashClient,
+  WorkflowServeOptions,
+} from "../types";
 import {
   WORKFLOW_FAILURE_HEADER,
   WORKFLOW_ID_HEADER,
@@ -1233,5 +1239,91 @@ describe("serve", () => {
       },
     });
     expect(called).toBeTrue();
+  });
+
+  test("should not validate callback payloads with workflow schema", async () => {
+    const callbackWorkflowRunId = `wfr_${nanoid()}`;
+    const childWorkflowRunId = `wfr_${nanoid()}`;
+    const stepName = "call workflow";
+    const publishedRequests: unknown[] = [];
+    const fakeQstashClient = {
+      http: {},
+      publishJSON: async (request: unknown) => {
+        publishedRequests.push(request);
+        return { messageId: "msgId" };
+      },
+    } as unknown as WorkflowQStashClient;
+    const callbackPayload = {
+      status: 200,
+      header: {
+        "Content-Type": ["text/plain;charset=UTF-8"],
+        "Upstash-Workflow-Sdk": ["v1.0.0"],
+      },
+      body: btoa(
+        JSON.stringify({
+          workflowRunId: childWorkflowRunId,
+          finishCondition: "success",
+        })
+      ),
+      sourceMessageId: `msg_${nanoid()}`,
+      url: `${WORKFLOW_ENDPOINT}/workflow-b`,
+      method: "POST",
+      sourceBody: btoa(JSON.stringify({ brandId: nanoid() })),
+      maxRetries: 2,
+    };
+
+    const { handler: endpoint } = serve(
+      async () => {
+        throw new Error("workflow should not run for callback requests");
+      },
+      {
+        qstashClient: fakeQstashClient,
+        receiver: undefined,
+        schema: z.object({ brandId: z.string() }),
+      }
+    );
+
+    const request = new Request(WORKFLOW_ENDPOINT, {
+      method: "POST",
+      body: JSON.stringify(callbackPayload),
+      headers: {
+        "Upstash-Workflow-Callback": "true",
+        "Upstash-Workflow-StepId": "3",
+        "Upstash-Workflow-StepName": stepName,
+        "Upstash-Workflow-StepType": "Call",
+        "Upstash-Workflow-Concurrent": "1",
+        "Upstash-Workflow-ContentType": "application/json",
+        [WORKFLOW_ID_HEADER]: callbackWorkflowRunId,
+      },
+    });
+
+    const response = await endpoint(request);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      workflowRunId: string;
+      finishCondition: FinishCondition;
+    };
+    expect(body.workflowRunId).toBe(callbackWorkflowRunId);
+    expect(body.finishCondition).toBe("fromCallback");
+    expect(publishedRequests).toEqual([
+      expect.objectContaining({
+        method: "POST",
+        url: WORKFLOW_ENDPOINT,
+        body: {
+          stepId: 3,
+          stepName,
+          stepType: "Call",
+          out: JSON.stringify({
+            status: 200,
+            body: JSON.stringify({
+              workflowRunId: childWorkflowRunId,
+              finishCondition: "success",
+            }),
+            header: callbackPayload.header,
+          }),
+          concurrent: 1,
+        },
+      }),
+    ]);
   });
 });

--- a/src/workflow-requests.ts
+++ b/src/workflow-requests.ts
@@ -10,6 +10,7 @@ import {
 } from "./error";
 import type { WorkflowContext } from "./context";
 import {
+  WORKFLOW_CALLBACK_HEADER,
   TELEMETRY_HEADER_FRAMEWORK,
   TELEMETRY_HEADER_RUNTIME,
   TELEMETRY_HEADER_SDK,
@@ -334,7 +335,7 @@ export const handleThirdPartyCallResult = async ({
   | Err<never, Error>
 > => {
   try {
-    if (request.headers.get("Upstash-Workflow-Callback")) {
+    if (request.headers.get(WORKFLOW_CALLBACK_HEADER)) {
       let callbackPayload: string;
       if (requestPayload) {
         callbackPayload = requestPayload;
@@ -469,7 +470,7 @@ export const handleThirdPartyCallResult = async ({
       return ok("continue-workflow");
     }
   } catch (error) {
-    const isCallReturn = request.headers.get("Upstash-Workflow-Callback");
+    const isCallReturn = request.headers.get(WORKFLOW_CALLBACK_HEADER);
     return err(
       new WorkflowError(`Error when handling call return (isCallReturn=${isCallReturn}): ${error}`)
     );


### PR DESCRIPTION
## Summary

This fixes a bug where workflows using `schema` could fail when receiving internal callback results from `context.call`.

The schema should validate the original workflow input, but callback requests are system messages from QStash. Before this change, those callback envelopes were being parsed as if they were user payloads, which caused valid workflow runs to fail with Zod errors.

## Why This Happens

`serveBase` created the `WorkflowContext` before checking whether the request was a callback result:

```ts
const workflowContext = new WorkflowContext({
  initialPayload: initialPayloadParser(rawInitialPayload),
  // ...
});

const callReturnCheck = await handleThirdPartyCallResult(...);
```

For callback requests, `rawInitialPayload` is shaped like this:

```json
{
  "status": 200,
  "header": {},
  "body": "base64-encoded-response",
  "sourceMessageId": "msg_...",
  "url": "https://example.com/api/workflows/workflow-b",
  "method": "POST"
}
```

That is not the workflow’s user input. So a workflow schema like this fails when the callback result comes back to `workflowA`, because the callback envelope does not contain `id`.

```ts
const workflowA = createWorkflow(
  async (context) => {
    await context.call("call workflow b", {
      workflow: workflowB,
      body: { id: context.requestPayload.id },
    });
  },
  { schema: z.object({ id: z.string() }) },
);
```

## When It Was Introduced

The underlying ordering issue has existed ever since the inception of this library.

It became visible after https://github.com/upstash/workflow-js/pull/55 added schema parsing to `initialPayloadParser`. Before schemas, the callback body could still be JSON-parsed and later handled. With Zod, the invalid shape caused a hard 500 before callback handling ran.

## What Changed

Callback handling now runs before normal workflow payload parsing and schema validation.

If `handleThirdPartyCallResult` returns:

- `continue-workflow`, the request continues through the normal workflow path.
- `workflow-ended`, the handler returns `workflow-already-ended`.
- `is-call-return` or `call-will-retry`, the handler returns `fromCallback`.

This keeps schema validation scoped to user workflow inputs and prevents internal QStash callback envelopes from being validated against user schemas.

## Tests

Added a regression test that serves a workflow with a strict Zod schema, sends an `Upstash-Workflow-Callback` payload, and verifies the callback is handled successfully instead of failing schema validation.