### PR TITLE
DX-2691: validate label and flow control key are alphanumeric

### DIFF
--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -10,6 +10,7 @@ import { Client as QStashClient } from "@upstash/qstash";
 import { getWorkflowRunId, nanoid } from "../utils";
 import { triggerFirstInvocation } from "../workflow-requests";
 import { WorkflowContext } from "../context";
+import { WorkflowNonRetryableError } from "../error";
 
 describe("workflow client", () => {
   const token = nanoid();
@@ -1294,5 +1295,82 @@ describe("workflow client", () => {
         timeout: 60000,
       }
     );
+  });
+
+  describe("trigger - input validation", () => {
+    test("should throw when label contains invalid characters", () => {
+      const promise = client.trigger({
+        url: WORKFLOW_ENDPOINT,
+        label: "bad label!",
+      });
+      expect(promise).rejects.toThrow(WorkflowNonRetryableError);
+      expect(promise).rejects.toThrow(/Invalid label/);
+    });
+
+    test("should throw when flowControl key contains invalid characters", () => {
+      const promise = client.trigger({
+        url: WORKFLOW_ENDPOINT,
+        flowControl: { key: "bad key!", parallelism: 1 },
+      });
+      expect(promise).rejects.toThrow(WorkflowNonRetryableError);
+      expect(promise).rejects.toThrow(/Invalid flow control key/);
+    });
+
+    test("should forward valid label and flow control headers", async () => {
+      const myWorkflowRunId = `mock-${getWorkflowRunId()}`;
+      await mockQStashServer({
+        execute: async () => {
+          await client.trigger({
+            url: WORKFLOW_ENDPOINT,
+            workflowRunId: myWorkflowRunId,
+            label: "valid_label.1",
+            flowControl: { key: "valid-key_1.0", parallelism: 5 },
+          });
+        },
+        responseFields: {
+          status: 200,
+          body: [{ messageId: "msgId" }],
+        },
+        receivesRequest: {
+          method: "POST",
+          url: `${MOCK_QSTASH_SERVER_URL}/v2/batch`,
+          token,
+          body: [
+            {
+              destination: WORKFLOW_ENDPOINT,
+              headers: {
+                "upstash-forward-upstash-workflow-sdk-version": "1",
+                "upstash-method": "POST",
+                "upstash-workflow-init": "true",
+                "upstash-workflow-runid": `wfr_${myWorkflowRunId}`,
+                "upstash-workflow-url": "https://requestcatcher.com/api",
+                "content-type": "application/json",
+                "upstash-feature-set": "LazyFetch,InitialBody,WF_DetectTrigger,WF_TriggerOnConfig",
+                "upstash-forward-upstash-label": "valid_label.1",
+                "upstash-label": "valid_label.1",
+                "upstash-flow-control-key": "valid-key_1.0",
+                "upstash-flow-control-value": "parallelism=5",
+                "upstash-telemetry-framework": "unknown",
+                "upstash-telemetry-runtime": expect.stringMatching(/bun@/),
+                "upstash-telemetry-sdk": expect.stringContaining("@upstash/workflow"),
+                "upstash-workflow-sdk-version": "1",
+                "upstash-failure-callback-forward-upstash-label": "valid_label.1",
+                "upstash-failure-callback": "https://requestcatcher.com/api",
+                "upstash-failure-callback-feature-set":
+                  "LazyFetch,InitialBody,WF_DetectTrigger,WF_TriggerOnConfig",
+                "upstash-failure-callback-flow-control-key": "valid-key_1.0",
+                "upstash-failure-callback-flow-control-value": "parallelism=5",
+                "upstash-failure-callback-forward-upstash-workflow-failure-callback": "true",
+                "upstash-failure-callback-forward-upstash-workflow-is-failure": "true",
+                "upstash-failure-callback-workflow-calltype": "failureCall",
+                "upstash-failure-callback-workflow-init": "false",
+                "upstash-failure-callback-workflow-runid": `wfr_${myWorkflowRunId}`,
+                "upstash-failure-callback-workflow-url": "https://requestcatcher.com/api",
+              },
+            },
+          ],
+        },
+      });
+    });
   });
 });

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,7 +1,7 @@
 import { NotifyResponse, Waiter } from "../types";
 import { Client as QStashClient } from "@upstash/qstash";
 import { buildBulkActionQueryParameters, makeGetWaitersRequest, makeNotifyRequest } from "./utils";
-import { getWorkflowRunId } from "../utils";
+import { getWorkflowRunId, validateFlowControl, validateLabel } from "../utils";
 import { triggerFirstInvocation } from "../workflow-requests";
 import { WorkflowContext } from "../context";
 import { DLQ } from "./dlq";
@@ -220,6 +220,9 @@ export class Client {
     const options = isBatchInput ? params : [params];
 
     const invocations = options.map((option) => {
+      validateLabel(option.label);
+      validateFlowControl(option.flowControl);
+
       const failureUrl = option.failureUrl ?? option.url;
       const finalWorkflowRunId = getWorkflowRunId(option.workflowRunId);
 

--- a/src/context/context.test.ts
+++ b/src/context/context.test.ts
@@ -4,7 +4,7 @@ import { MOCK_QSTASH_SERVER_URL, mockQStashServer, WORKFLOW_ENDPOINT } from "../
 import { WorkflowContext } from "./context";
 import { Client } from "@upstash/qstash";
 import { nanoid } from "../utils";
-import { WorkflowCancelAbort, WorkflowError } from "../error";
+import { WorkflowCancelAbort, WorkflowError, WorkflowNonRetryableError } from "../error";
 import {
   WORKFLOW_ID_HEADER,
   WORKFLOW_INIT_HEADER,
@@ -1077,6 +1077,107 @@ describe("context tests", () => {
                 "upstash-feature-set": "LazyFetch,InitialBody,WF_DetectTrigger,WF_TriggerOnConfig",
                 "upstash-forward-upstash-workflow-sdk-version": "1",
                 "upstash-method": "POST",
+                "upstash-workflow-init": "false",
+                "upstash-workflow-runid": "wfr-id",
+                "upstash-workflow-url": WORKFLOW_ENDPOINT,
+              },
+            },
+          ],
+        },
+      });
+    });
+  });
+
+  describe("label and flow control validation", () => {
+    const buildContext = () =>
+      new WorkflowContext({
+        qstashClient,
+        initialPayload: "my-payload",
+        steps: [],
+        url: WORKFLOW_ENDPOINT,
+        headers: new Headers() as Headers,
+        workflowRunId: "wfr-id",
+        workflowRunCreatedAt: 0,
+      });
+
+    test("context.invoke should reject invalid label", async () => {
+      const context = buildContext();
+      const promise = context.invoke("invoke-step", {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        workflow: { workflowId: "some-workflow" } as any,
+        body: undefined,
+        label: "bad label!",
+      });
+      expect(promise).rejects.toThrow(WorkflowNonRetryableError);
+      expect(promise).rejects.toThrow(/Invalid label/);
+    });
+
+    test("context.invoke should reject invalid flow control key", async () => {
+      const context = buildContext();
+      const promise = context.invoke("invoke-step", {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        workflow: { workflowId: "some-workflow" } as any,
+        body: undefined,
+        flowControl: { key: "bad key!", parallelism: 1 },
+      });
+      expect(promise).rejects.toThrow(WorkflowNonRetryableError);
+      expect(promise).rejects.toThrow(/Invalid flow control key/);
+    });
+
+    test("context.call should reject invalid flow control key", async () => {
+      const context = buildContext();
+      const promise = context.call("call-step", {
+        url: "https://some-website.com",
+        flowControl: { key: "bad key!", parallelism: 1 },
+      });
+      expect(promise).rejects.toThrow(WorkflowNonRetryableError);
+      expect(promise).rejects.toThrow(/Invalid flow control key/);
+    });
+
+    test("context.call should accept valid flow control key and forward headers", async () => {
+      const context = buildContext();
+      await mockQStashServer({
+        execute: () => {
+          const throws = () =>
+            context.call("call-step", {
+              url: "https://some-website.com",
+              flowControl: { key: "valid-key_1.0", parallelism: 3 },
+            });
+          expect(throws).toThrowError("Aborting workflow after executing step 'call-step'.");
+        },
+        responseFields: {
+          status: 200,
+          body: "msgId",
+        },
+        receivesRequest: {
+          method: "POST",
+          url: `${MOCK_QSTASH_SERVER_URL}/v2/batch`,
+          token,
+          body: [
+            {
+              destination: "https://some-website.com",
+              headers: {
+                "upstash-workflow-sdk-version": "1",
+                "content-type": "application/json",
+                "upstash-callback": WORKFLOW_ENDPOINT,
+                "upstash-callback-feature-set":
+                  "LazyFetch,InitialBody,WF_DetectTrigger,WF_TriggerOnConfig",
+                "upstash-callback-forward-upstash-workflow-callback": "true",
+                "upstash-callback-forward-upstash-workflow-concurrent": "1",
+                "upstash-callback-forward-upstash-workflow-contenttype": "application/json",
+                "upstash-callback-forward-upstash-workflow-stepid": "1",
+                "upstash-callback-forward-upstash-workflow-stepname": "call-step",
+                "upstash-callback-forward-upstash-workflow-steptype": "Call",
+                "upstash-callback-workflow-calltype": "fromCallback",
+                "upstash-callback-workflow-init": "false",
+                "upstash-callback-workflow-runid": "wfr-id",
+                "upstash-callback-workflow-url": WORKFLOW_ENDPOINT,
+                "upstash-feature-set": "WF_NoDelete,InitialBody",
+                "upstash-flow-control-key": "valid-key_1.0",
+                "upstash-flow-control-value": "parallelism=3",
+                "upstash-method": "GET",
+                "upstash-retries": "0",
+                "upstash-workflow-calltype": "toCallback",
                 "upstash-workflow-init": "false",
                 "upstash-workflow-runid": "wfr-id",
                 "upstash-workflow-url": WORKFLOW_ENDPOINT,

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -28,6 +28,7 @@ import { WorkflowApi } from "./api";
 import { getNewUrlFromWorkflowId } from "../serve/serve-many";
 import { MiddlewareManager } from "../middleware/manager";
 import { QstashError } from "@upstash/qstash";
+import { validateFlowControl, validateLabel } from "../utils";
 
 /**
  * Upstash Workflow context
@@ -340,8 +341,10 @@ export class WorkflowContext<TInitialPayload = unknown> {
     stepName: string,
     settings: CallSettings | (LazyInvokeStepParams<TBody, unknown> & Pick<CallSettings, "timeout">)
   ): Promise<CallResponse<TResult | { workflowRunId: string }>> {
+    validateFlowControl(settings.flowControl);
     let callStep: LazyCallStep<TResult | { workflowRunId: string }>;
     if ("workflow" in settings) {
+      validateLabel(settings.label);
       const url = getNewUrlFromWorkflowId(this.url, settings.workflow.workflowId);
       const stringBody =
         typeof settings.body === "string"
@@ -473,6 +476,8 @@ export class WorkflowContext<TInitialPayload = unknown> {
     stepName: string,
     settings: LazyInvokeStepParams<TInitialPayload, TResult>
   ) {
+    validateLabel(settings.label);
+    validateFlowControl(settings.flowControl);
     return await this.addStep(
       new LazyInvokeStep<TResult, TInitialPayload>(this, stepName, settings)
     );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,27 @@
-import { WorkflowError } from "./error";
+import { WorkflowError, WorkflowNonRetryableError } from "./error";
+import type { FlowControl } from "@upstash/qstash";
 import { WorkflowClient } from "./types";
 
 const NANOID_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_";
 const NANOID_LENGTH = 21;
+
+const RESOURCE_NAME_PATTERN = /^[a-zA-Z0-9\-_.]+$/;
+
+export function validateLabel(label: string | undefined): void {
+  if (label !== undefined && !RESOURCE_NAME_PATTERN.test(label)) {
+    throw new WorkflowNonRetryableError(
+      `Invalid label "${label}": must be alphanumeric, hyphen, underscore, or period.`
+    );
+  }
+}
+
+export function validateFlowControl(flowControl: FlowControl | undefined): void {
+  if (flowControl?.key !== undefined && !RESOURCE_NAME_PATTERN.test(flowControl.key)) {
+    throw new WorkflowNonRetryableError(
+      `Invalid flow control key "${flowControl.key}": must be alphanumeric, hyphen, underscore, or period.`
+    );
+  }
+}
 
 function getRandomInt() {
   return Math.floor(Math.random() * NANOID_CHARS.length);


### PR DESCRIPTION
DX-2691

Mirror the backend's ValidateResourceName check (^[a-zA-Z0-9-_.]+$) on the SDK side for client.trigger, context.invoke, and context.call. Invalid values throw WorkflowNonRetryableError before the QStash request is made.