### PR TITLE
DX-2705: feat: eager-start QStash dev server on serve() across all adapters

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -425,7 +425,10 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # node 24 so we get npm 11: npm 10 (bundled with node 20) crashes
+          # with "Cannot read properties of null (reading 'edgesOut')" on the
+          # vite 8 / @vitejs/devtools peer-dependency cycle pulled in by nuxt.
+          node-version: 24
 
       - name: Install Dependencies
         run: npm install

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@upstash/workflow",
       "dependencies": {
-        "@upstash/qstash": "0.0.0-ci.8c658c13532090cf00f778d2216eacbad68f85f9-20260618065901",
+        "@upstash/qstash": "^2.11.3",
       },
       "devDependencies": {
         "@commitlint/cli": "^19.5.0",
@@ -521,7 +521,7 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
-    "@upstash/qstash": ["@upstash/qstash@0.0.0-ci.8c658c13532090cf00f778d2216eacbad68f85f9-20260618065901", "", { "dependencies": { "crypto-js": ">=4.2.0", "jose": "^5.2.3", "neverthrow": "^7.0.1" } }, "sha512-Tezvd3lUcZzbf5PaUCxuCTFZTw+t6Zb2xjuZsx5WzhRCvlJ+FZdc79tNTnye4HUbMjbPMiS2c589kzd10eRmXg=="],
+    "@upstash/qstash": ["@upstash/qstash@2.11.3", "", { "dependencies": { "crypto-js": ">=4.2.0", "jose": "^5.2.3", "neverthrow": "^7.0.1" } }, "sha512-d5saGTDlkbKDFSANENtyf+zqkJen9ho17S24x9lXo+DwWjZ9IDM5WKUzUsshUv8ufZsSpxJWyrZ8jZ6r8dBuhg=="],
 
     "@vercel/nft": ["@vercel/nft@1.5.0", "", { "dependencies": { "@mapbox/node-pre-gyp": "^2.0.0", "@rollup/pluginutils": "^5.1.3", "acorn": "^8.6.0", "acorn-import-attributes": "^1.9.5", "async-sema": "^3.1.1", "bindings": "^1.4.0", "estree-walker": "2.0.2", "glob": "^13.0.0", "graceful-fs": "^4.2.9", "node-gyp-build": "^4.2.2", "picomatch": "^4.0.2", "resolve-from": "^5.0.0" }, "bin": { "nft": "out/cli.js" } }, "sha512-IWTDeIoWhQ7ZtRO/JRKH+jhmeQvZYhtGPmzw/QGDY+wDCQqfm25P9yIdoAFagu4fWsK4IwZXDFIjrmp5rRm/sA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@upstash/workflow",
       "dependencies": {
-        "@upstash/qstash": "^2.11.0",
+        "@upstash/qstash": "0.0.0-ci.8c658c13532090cf00f778d2216eacbad68f85f9-20260618065901",
       },
       "devDependencies": {
         "@commitlint/cli": "^19.5.0",
@@ -521,7 +521,7 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
-    "@upstash/qstash": ["@upstash/qstash@2.11.0", "", { "dependencies": { "crypto-js": ">=4.2.0", "jose": "^5.2.3", "neverthrow": "^7.0.1" } }, "sha512-AfPPxsUeOJCrxMQ9dkh1RZL40wgxCsUNFkxrbBSomC3U4j4qKFRawU8sDK+dqqH+sZFUS1biVM4GK46d5Tg2Vg=="],
+    "@upstash/qstash": ["@upstash/qstash@0.0.0-ci.8c658c13532090cf00f778d2216eacbad68f85f9-20260618065901", "", { "dependencies": { "crypto-js": ">=4.2.0", "jose": "^5.2.3", "neverthrow": "^7.0.1" } }, "sha512-Tezvd3lUcZzbf5PaUCxuCTFZTw+t6Zb2xjuZsx5WzhRCvlJ+FZdc79tNTnye4HUbMjbPMiS2c589kzd10eRmXg=="],
 
     "@vercel/nft": ["@vercel/nft@1.5.0", "", { "dependencies": { "@mapbox/node-pre-gyp": "^2.0.0", "@rollup/pluginutils": "^5.1.3", "acorn": "^8.6.0", "acorn-import-attributes": "^1.9.5", "async-sema": "^3.1.1", "bindings": "^1.4.0", "estree-walker": "2.0.2", "glob": "^13.0.0", "graceful-fs": "^4.2.9", "node-gyp-build": "^4.2.2", "picomatch": "^4.0.2", "resolve-from": "^5.0.0" }, "bin": { "nft": "out/cli.js" } }, "sha512-IWTDeIoWhQ7ZtRO/JRKH+jhmeQvZYhtGPmzw/QGDY+wDCQqfm25P9yIdoAFagu4fWsK4IwZXDFIjrmp5rRm/sA=="],
 

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "typescript-eslint": "^8.18.0"
   },
   "dependencies": {
-    "@upstash/qstash": "0.0.0-ci.8c658c13532090cf00f778d2216eacbad68f85f9-20260618065901"
+    "@upstash/qstash": "^2.11.3"
   },
   "directories": {
     "example": "examples"

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "typescript-eslint": "^8.18.0"
   },
   "dependencies": {
-    "@upstash/qstash": "^2.11.0"
+    "@upstash/qstash": "0.0.0-ci.8c658c13532090cf00f778d2216eacbad68f85f9-20260618065901"
   },
   "directories": {
     "example": "examples"

--- a/platforms/astro.ts
+++ b/platforms/astro.ts
@@ -4,6 +4,7 @@ import { InvokableWorkflow, WorkflowServeOptions, Telemetry, WorkflowContext } f
 import { serveBase } from "../src/serve";
 import { SDK_TELEMETRY } from "../src/constants";
 import { serveManyBase } from "../src/serve/serve-many";
+import { startDevServer } from "@upstash/qstash";
 
 const telemetry: Telemetry = {
   sdk: SDK_TELEMETRY,
@@ -20,6 +21,8 @@ export function serve<TInitialPayload = unknown, TResult = unknown>(
   ) => Promise<TResult>,
   options?: WorkflowServeOptions<TInitialPayload, TResult>
 ) {
+  void startDevServer();
+
   const POST: APIRoute = (apiContext) => {
     const { handler } = serveBase<TInitialPayload, Request, Response, TResult>(
       (workflowContext) => routeFunction(workflowContext, apiContext),

--- a/platforms/cloudflare.ts
+++ b/platforms/cloudflare.ts
@@ -2,6 +2,7 @@ import type { InvokableWorkflow, WorkflowServeOptions, RouteFunction, Telemetry 
 import { SDK_TELEMETRY } from "../src/constants";
 import { serveBase } from "../src/serve";
 import { serveManyBase } from "../src/serve/serve-many";
+import { startDevServer } from "@upstash/qstash";
 
 export type WorkflowBindings = {
   QSTASH_TOKEN: string;
@@ -69,6 +70,8 @@ export const serve = <TInitialPayload = unknown, TResult = unknown>(
 ): {
   fetch: (...args: PagesHandlerArgs | WorkersHandlerArgs) => Promise<Response>;
 } => {
+  void startDevServer();
+
   const fetch = async (...args: PagesHandlerArgs | WorkersHandlerArgs) => {
     const { request, env } = getArgs(args);
     const { handler: serveHandler } = serveBase(routeFunction, telemetry, {

--- a/platforms/express.ts
+++ b/platforms/express.ts
@@ -8,6 +8,7 @@ import {
   RequestHandler,
 } from "express";
 import { serveManyBase } from "../src/serve/serve-many";
+import { startDevServer } from "@upstash/qstash";
 
 const isEmptyRequest = (req: ExpressRequest) => {
   return (
@@ -83,6 +84,8 @@ export function serve<TInitialPayload = unknown, TResult = unknown>(
   routeFunction: RouteFunction<TInitialPayload, TResult>,
   options?: WorkflowServeOptions<TInitialPayload, TResult>
 ): Router {
+  void startDevServer();
+
   const router = Router();
 
   const handler: RequestHandler = createExpressHandler([routeFunction, options]);
@@ -108,6 +111,10 @@ export const serveMany = (
   workflows: Parameters<typeof serveManyBase>[0]["workflows"],
   options?: Parameters<typeof serveManyBase>[0]["options"]
 ) => {
+  // serveMany's serveMethod uses createExpressHandler (not serve), so start the
+  // dev server here too. No-op unless QSTASH_DEV is set.
+  void startDevServer();
+
   const router = Router();
 
   const { handler } = serveManyBase<ReturnType<typeof createExpressHandler>>({

--- a/platforms/h3.ts
+++ b/platforms/h3.ts
@@ -5,6 +5,7 @@ import { serveBase } from "../src/serve";
 import type { IncomingHttpHeaders } from "node:http";
 import { SDK_TELEMETRY } from "../src/constants";
 import { serveManyBase } from "../src/serve/serve-many";
+import { startDevServer } from "@upstash/qstash";
 
 function transformHeaders(headers: IncomingHttpHeaders): [string, string][] {
   const formattedHeaders = Object.entries(headers).map(([key, value]) => [
@@ -34,6 +35,8 @@ export const serve = <TInitialPayload = unknown, TResult = unknown>(
   routeFunction: RouteFunction<TInitialPayload, TResult>,
   options?: WorkflowServeOptions<TInitialPayload, TResult>
 ) => {
+  void startDevServer();
+
   const handler = defineEventHandler(async (event) => {
     const method = event.node.req.method;
     if (method?.toUpperCase() !== "POST") {

--- a/platforms/hono.ts
+++ b/platforms/hono.ts
@@ -4,6 +4,7 @@ import { serveBase } from "../src/serve";
 import { Variables } from "hono/types";
 import { SDK_TELEMETRY } from "../src/constants";
 import { serveManyBase } from "../src/serve/serve-many";
+import { startDevServer } from "@upstash/qstash";
 
 export type WorkflowBindings = {
   QSTASH_TOKEN: string;
@@ -36,6 +37,8 @@ export const serve = <
   routeFunction: RouteFunction<TInitialPayload, TResult>,
   options?: WorkflowServeOptions<TInitialPayload, TResult>
 ): ((context: Context<{ Bindings: TBindings; Variables: TVariables }>) => Promise<Response>) => {
+  void startDevServer();
+
   const handler = async (context: Context<{ Bindings: TBindings; Variables: TVariables }>) => {
     const environment = context.env
       ? context.env

--- a/platforms/nextjs.ts
+++ b/platforms/nextjs.ts
@@ -6,6 +6,7 @@ import type { RouteFunction, WorkflowServeOptions, Telemetry, InvokableWorkflow 
 import { serveBase } from "../src/serve";
 import { SDK_TELEMETRY } from "../src/constants";
 import { serveManyBase } from "../src/serve/serve-many";
+import { startDevServer } from "@upstash/qstash";
 
 const appTelemetry: Telemetry = {
   sdk: SDK_TELEMETRY,
@@ -34,6 +35,8 @@ export const serve = <TInitialPayload = unknown, TResult = unknown>(
   routeFunction: RouteFunction<TInitialPayload, TResult>,
   options?: WorkflowServeOptions<TInitialPayload, TResult>
 ) => {
+  void startDevServer();
+
   const { handler: serveHandler } = serveBase<TInitialPayload, Request, Response, TResult>(
     routeFunction,
     appTelemetry,
@@ -80,6 +83,8 @@ export const servePagesRouter = <TInitialPayload = unknown, TResult = unknown>(
 ): {
   handler: NextApiHandler;
 } => {
+  void startDevServer();
+
   const { handler: serveHandler } = serveBase(routeFunction, pagesTelemetry, options, undefined);
 
   const handler = async (request_: NextApiRequest, res: NextApiResponse) => {

--- a/platforms/react-router.ts
+++ b/platforms/react-router.ts
@@ -2,6 +2,7 @@ import type { WorkflowServeOptions, RouteFunction, Telemetry, InvokableWorkflow 
 import { SDK_TELEMETRY } from "../src/constants";
 import { serveBase } from "../src/serve";
 import { serveManyBase } from "../src/serve/serve-many";
+import { startDevServer } from "@upstash/qstash";
 
 const telemetry: Telemetry = {
   sdk: SDK_TELEMETRY,
@@ -39,6 +40,8 @@ export const serve = <TInitialPayload = unknown, TResult = unknown>(
   routeFunction: RouteFunction<TInitialPayload, TResult>,
   options?: WorkflowServeOptions<TInitialPayload, TResult>
 ) => {
+  void startDevServer();
+
   const { handler: serveHandler } = serveBase<TInitialPayload, Request, Response, TResult>(
     routeFunction,
     telemetry,

--- a/platforms/solidjs.ts
+++ b/platforms/solidjs.ts
@@ -3,6 +3,7 @@ import type { APIEvent } from "@solidjs/start/server";
 import type { WorkflowServeOptions, RouteFunction, Telemetry } from "../src";
 import { serveBase } from "../src/serve";
 import { SDK_TELEMETRY } from "../src/constants";
+import { startDevServer } from "@upstash/qstash";
 
 /**
  * Serve method to serve a Upstash Workflow in a SolidJS project
@@ -17,6 +18,8 @@ export const serve = <TInitialPayload = unknown, TResult = unknown>(
   routeFunction: RouteFunction<TInitialPayload, TResult>,
   options?: WorkflowServeOptions<TInitialPayload, TResult>
 ) => {
+  void startDevServer();
+
   const telemetry: Telemetry = {
     sdk: SDK_TELEMETRY,
     framework: "solidjs",

--- a/platforms/svelte.ts
+++ b/platforms/svelte.ts
@@ -4,6 +4,7 @@ import type { InvokableWorkflow, WorkflowServeOptions, RouteFunction, Telemetry 
 import { serveBase } from "../src/serve";
 import { SDK_TELEMETRY } from "../src/constants";
 import { OmitOptionsInServeMany, serveManyBase } from "../src/serve/serve-many";
+import { startDevServer } from "@upstash/qstash";
 
 const telemetry: Telemetry = {
   sdk: SDK_TELEMETRY,
@@ -31,6 +32,8 @@ export const serve = <TInitialPayload = unknown, TResult = unknown>(
 ): {
   POST: RequestHandler;
 } => {
+  void startDevServer();
+
   const handler: RequestHandler = async ({ request }) => {
     const { handler: serveHandler } = serveBase<TInitialPayload, Request, Response, TResult>(
       routeFunction,

--- a/platforms/tanstack.ts
+++ b/platforms/tanstack.ts
@@ -8,6 +8,7 @@ import type {
 import { serveBase } from "../src/serve";
 import { SDK_TELEMETRY } from "../src/constants";
 import { serveManyBase } from "../src/serve/serve-many";
+import { startDevServer } from "@upstash/qstash";
 
 const telemetry: Telemetry = {
   sdk: SDK_TELEMETRY,
@@ -32,6 +33,8 @@ export function serve<TInitialPayload = unknown, TResult = unknown>(
   > &
     ExclusiveValidationOptions<TInitialPayload>
 ) {
+  void startDevServer();
+
   const POST = (tanstackContext: { request: Request }) => {
     // Create a Next.js compatible handler that passes the route context
     const { handler } = serveBase<TInitialPayload, Request, Response, TResult>(

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -7,6 +7,7 @@ import {
   eventually,
 } from "../test-utils";
 import { Client } from ".";
+import type { WorkflowRunCancelFilters } from "./filter-types";
 import { Client as QStashClient } from "@upstash/qstash";
 import { getWorkflowRunId, nanoid } from "../utils";
 import { triggerFirstInvocation } from "../workflow-requests";
@@ -544,6 +545,23 @@ describe("workflow client", () => {
       token: process.env.QSTASH_TOKEN!,
     });
 
+    // Cancel-by-filter on live QStash is eventually consistent: a run triggered
+    // moments ago may not be matched by the very next cancel call. Poll,
+    // accumulating cancelled counts, until the expected total is reached (or the
+    // deadline passes) so indexing lag doesn't flake the assertions below.
+    const cancelExpecting = async (
+      request: WorkflowRunCancelFilters | { urlStartingWith: string },
+      expected: number
+    ): Promise<number> => {
+      let cancelled = 0;
+      const deadline = Date.now() + 10_000;
+      for (;;) {
+        cancelled += (await liveClient.cancel(request)).cancelled;
+        if (cancelled >= expected || Date.now() > deadline) return cancelled;
+        await Bun.sleep(500);
+      }
+    };
+
     test(
       "should cancel single workflow run id",
       async () => {
@@ -595,23 +613,15 @@ describe("workflow client", () => {
     test(
       "should cancel with workflowUrlStartingWith (prefix match)",
       async () => {
-        await liveClient.trigger({
-          url: `${MOCK_DESTINATION_HOST}//first`,
-          delay: "2s",
-        });
-        await liveClient.trigger({
-          url: `${MOCK_DESTINATION_HOST}//second`,
-          delay: "2s",
-        });
+        // unique per run so leftovers from an earlier failed run can't inflate the count
+        const prefix = `${MOCK_DESTINATION_HOST}/prefix-${nanoid()}/`;
+        await liveClient.trigger({ url: `${prefix}first`, delay: "1m" });
+        await liveClient.trigger({ url: `${prefix}second`, delay: "1m" });
 
-        const cancel = await liveClient.cancel({
-          urlStartingWith: `${MOCK_DESTINATION_HOST}//`,
-        });
-
-        expect(cancel).toEqual({ cancelled: 2 });
+        expect(await cancelExpecting({ urlStartingWith: prefix }, 2)).toBe(2);
       },
       {
-        timeout: 10000,
+        timeout: 30000,
       }
     );
 
@@ -620,59 +630,53 @@ describe("workflow client", () => {
       async () => {
         const label = `test-label-${nanoid()}`;
 
+        // delay keeps the runs pending: without it prod can deliver (and finish)
+        // a run before the cancel-by-label lands, undercounting the result
         await liveClient.trigger({
           url: `${MOCK_DESTINATION_HOST}/label-test`,
           label,
+          delay: "1m",
         });
         await liveClient.trigger({
           url: `${MOCK_DESTINATION_HOST}/label-test`,
           label,
+          delay: "1m",
         });
         // different label, should not be cancelled
         const { workflowRunId: id3 } = await liveClient.trigger({
           url: `${MOCK_DESTINATION_HOST}/label-test`,
           label: `other-label-${nanoid()}`,
+          delay: "1m",
         });
 
-        const cancel = await liveClient.cancel({ filter: { label } });
-        expect(cancel).toEqual({ cancelled: 2 });
-
-        // clean up the remaining workflow
-        await liveClient.cancel(id3);
+        try {
+          expect(await cancelExpecting({ filter: { label } }, 2)).toBe(2);
+        } finally {
+          // clean up the remaining workflow
+          await liveClient.cancel(id3).catch(() => {});
+        }
       },
       {
-        timeout: 15000,
+        timeout: 30000,
       }
     );
 
     test(
       "should cancel with workflowUrl (exact match)",
       async () => {
-        await liveClient.trigger({
-          url: `${MOCK_DESTINATION_HOST}/exact-match-test`,
-          delay: "1m",
-        });
-        await liveClient.trigger({
-          url: `${MOCK_DESTINATION_HOST}/exact-match-test/sub-path`,
-          delay: "1m",
-        });
+        // unique per run so leftovers from an earlier failed run can't inflate the count
+        const base = `${MOCK_DESTINATION_HOST}/exact-match-${nanoid()}`;
+        await liveClient.trigger({ url: base, delay: "1m" });
+        await liveClient.trigger({ url: `${base}/sub-path`, delay: "1m" });
 
         // exact match should only cancel the exact URL
-        const cancel = await liveClient.cancel({
-          filter: {
-            workflowUrl: `${MOCK_DESTINATION_HOST}/exact-match-test`,
-          },
-        });
-        expect(cancel).toEqual({ cancelled: 1 });
+        expect(await cancelExpecting({ filter: { workflowUrl: base } }, 1)).toBe(1);
 
         // clean up the remaining workflow (prefix match)
-        const cleanup = await liveClient.cancel({
-          filter: { workflowUrlStartingWith: `${MOCK_DESTINATION_HOST}/exact-match-test` },
-        });
-        expect(cleanup).toEqual({ cancelled: 1 });
+        expect(await cancelExpecting({ filter: { workflowUrlStartingWith: base } }, 1)).toBe(1);
       },
       {
-        timeout: 15000,
+        timeout: 30000,
       }
     );
 
@@ -688,15 +692,14 @@ describe("workflow client", () => {
         const { workflowRunId: idC } = await liveClient.trigger({ url: urlC, delay: "1m" });
 
         // Cancelling [urlA, urlB] with exact match cancels exactly those two, not urlC.
-        const cancel = await liveClient.cancel({ filter: { workflowUrl: [urlA, urlB] } });
-        expect(cancel).toEqual({ cancelled: 2 });
+        expect(await cancelExpecting({ filter: { workflowUrl: [urlA, urlB] } }, 2)).toBe(2);
 
         // clean up the untouched run
         const cleanup = await liveClient.cancel(idC);
         expect(cleanup).toEqual({ cancelled: 1 });
       },
       {
-        timeout: 15000,
+        timeout: 30000,
       }
     );
 
@@ -708,32 +711,41 @@ describe("workflow client", () => {
         await liveClient.trigger({
           url: `${MOCK_DESTINATION_HOST}/combined-test`,
           label,
+          delay: "1m",
         });
         // same URL, different label — should NOT be cancelled
         const { workflowRunId: otherId } = await liveClient.trigger({
           url: `${MOCK_DESTINATION_HOST}/combined-test`,
           label: `other-${nanoid()}`,
+          delay: "1m",
         });
 
-        const cancel = await liveClient.cancel({
-          filter: {
-            workflowUrl: `${MOCK_DESTINATION_HOST}/combined-test`,
-            label,
-          },
-        });
-        expect(cancel).toEqual({ cancelled: 1 });
-
-        // clean up
-        await liveClient.cancel(otherId);
+        try {
+          expect(
+            await cancelExpecting(
+              { filter: { workflowUrl: `${MOCK_DESTINATION_HOST}/combined-test`, label } },
+              1
+            )
+          ).toBe(1);
+        } finally {
+          // clean up
+          await liveClient.cancel(otherId).catch(() => {});
+        }
       },
       {
-        timeout: 15000,
+        timeout: 30000,
       }
     );
 
     test(
       "should cancel by destination host and path",
       async () => {
+        // The hosts are shared across runs (prod refuses trigger URLs whose host
+        // doesn't resolve, so they can't be made unique) — sweep leftovers from
+        // earlier failed runs so they can't inflate this run's counts.
+        await liveClient.cancel({ filter: { host: "example.org" } }).catch(() => {});
+        await liveClient.cancel({ filter: { host: "example.com" } }).catch(() => {});
+
         const comPath = `/cancel-host-com-${nanoid()}`;
         const orgPath = `/cancel-host-org-${nanoid()}`;
 
@@ -741,15 +753,13 @@ describe("workflow client", () => {
         await liveClient.trigger({ url: `https://example.org${orgPath}`, delay: "1m" });
 
         // host example.org must not touch the example.com run
-        const byHost = await liveClient.cancel({ filter: { host: "example.org" } });
-        expect(byHost).toEqual({ cancelled: 1 });
+        expect(await cancelExpecting({ filter: { host: "example.org" } }, 1)).toBe(1);
 
         // the example.com run survived — cancel it via its unique path
-        const byPath = await liveClient.cancel({ filter: { path: comPath } });
-        expect(byPath).toEqual({ cancelled: 1 });
+        expect(await cancelExpecting({ filter: { path: comPath } }, 1)).toBe(1);
       },
       {
-        timeout: 15000,
+        timeout: 30000,
       }
     );
 
@@ -779,8 +789,7 @@ describe("workflow client", () => {
 
         try {
           // each label individually should match the run
-          const cancelByFirst = await liveClient.cancel({ filter: { label: labelOne } });
-          expect(cancelByFirst).toEqual({ cancelled: 1 });
+          expect(await cancelExpecting({ filter: { label: labelOne } }, 1)).toBe(1);
 
           // second cancel is a no-op since the run is already cancelled
           const cancelBySecond = await liveClient.cancel({ filter: { label: labelTwo } });
@@ -790,7 +799,7 @@ describe("workflow client", () => {
           await liveClient.cancel(workflowRunId).catch(() => {});
         }
       },
-      { timeout: 15000 }
+      { timeout: 30000 }
     );
   });
 

--- a/src/serve/dev-server-eager-start.test.ts
+++ b/src/serve/dev-server-eager-start.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Pins the eager-start regression (DX-2705): defining a workflow route by
+ * calling an adapter's `serve()` / `serveMany()` factory must start the QStash
+ * dev server *synchronously at factory-call time* — NOT deferred to the first
+ * inbound request, which is how every lazy adapter behaved before this change.
+ *
+ * We assert at the `@upstash/qstash` boundary by mocking `startDevServer`, the
+ * single call each adapter makes. (Prior art for the "drive the public entry,
+ * assert at the qstash boundary" approach: multi-region/multi-region.test.ts.)
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as realQstash from "@upstash/qstash";
+
+const startDevServer = mock(() => Promise.resolve());
+
+// Keep the real Client/Receiver/etc.; only intercept startDevServer. Registered
+// before the adapters are imported (below) so they pick up the mocked export.
+void mock.module("@upstash/qstash", () => ({
+  ...realQstash,
+  startDevServer,
+}));
+
+// Import the adapters dynamically AFTER the mock is registered.
+const hono = await import("../../platforms/hono");
+const cloudflare = await import("../../platforms/cloudflare");
+const express = await import("../../platforms/express");
+const svelte = await import("../../platforms/svelte");
+const h3 = await import("../../platforms/h3");
+const solidjs = await import("../../platforms/solidjs");
+const astro = await import("../../platforms/astro");
+const tanstack = await import("../../platforms/tanstack");
+const nextjs = await import("../../platforms/nextjs");
+const reactRouter = await import("../../platforms/react-router");
+
+const routeFunction = async () => {};
+
+// Every public serve-like factory should start the dev server when the route is
+// defined. `defineRoute` calls the factory but never invokes the returned
+// request handler — so a passing assertion proves the start was NOT deferred.
+const factories: { name: string; defineRoute: () => unknown }[] = [
+  { name: "hono.serve", defineRoute: () => hono.serve(routeFunction) },
+  { name: "cloudflare.serve", defineRoute: () => cloudflare.serve(routeFunction) },
+  { name: "express.serve", defineRoute: () => express.serve(routeFunction) },
+  { name: "svelte.serve", defineRoute: () => svelte.serve(routeFunction, { env: {} }) },
+  { name: "h3.serve", defineRoute: () => h3.serve(routeFunction) },
+  { name: "solidjs.serve", defineRoute: () => solidjs.serve(routeFunction) },
+  { name: "astro.serve", defineRoute: () => astro.serve(routeFunction) },
+  { name: "tanstack.serve", defineRoute: () => tanstack.serve(routeFunction) },
+  { name: "nextjs.serve", defineRoute: () => nextjs.serve(routeFunction) },
+  { name: "nextjs.servePagesRouter", defineRoute: () => nextjs.servePagesRouter(routeFunction) },
+  { name: "reactRouter.serve", defineRoute: () => reactRouter.serve(routeFunction) },
+];
+
+// serveMany factories. For most adapters serveMethod is the adapter `serve`, so
+// they are covered transitively; express is the exception (its serveMethod is an
+// internal handler, not `serve`) and so starts the dev server in serveMany itself.
+const serveManyFactories: { name: string; defineRoutes: () => unknown }[] = [
+  {
+    name: "hono.serveMany",
+    defineRoutes: () => hono.serveMany({ wf: hono.createWorkflow(routeFunction) }),
+  },
+  {
+    name: "express.serveMany",
+    defineRoutes: () => express.serveMany({ wf: express.createWorkflow(routeFunction) }),
+  },
+  {
+    name: "nextjs.serveMany",
+    defineRoutes: () => nextjs.serveMany({ wf: nextjs.createWorkflow(routeFunction) }),
+  },
+  {
+    name: "nextjs.serveManyPagesRouter",
+    defineRoutes: () =>
+      nextjs.serveManyPagesRouter({ wf: nextjs.createWorkflowPagesRouter(routeFunction) }),
+  },
+];
+
+describe("adapters eagerly start the QStash dev server on serve()", () => {
+  let prevQstashDev: string | undefined;
+
+  beforeEach(() => {
+    // Eager adapters (nextjs, react-router) construct a real Client in serve();
+    // make sure a machine-level QSTASH_DEV=true doesn't make that real Client
+    // spawn an actual dev server during this unit test.
+    prevQstashDev = process.env.QSTASH_DEV;
+    delete process.env.QSTASH_DEV;
+    startDevServer.mockClear();
+  });
+
+  afterEach(() => {
+    if (prevQstashDev === undefined) delete process.env.QSTASH_DEV;
+    else process.env.QSTASH_DEV = prevQstashDev;
+  });
+
+  for (const { name, defineRoute } of factories) {
+    test(`${name} starts the dev server synchronously at factory-call time`, () => {
+      expect(startDevServer).not.toHaveBeenCalled();
+      defineRoute();
+      // Synchronously after defining the route and before any inbound request.
+      expect(startDevServer).toHaveBeenCalledTimes(1);
+    });
+  }
+
+  for (const { name, defineRoutes } of serveManyFactories) {
+    test(`${name} starts the dev server at setup time`, () => {
+      expect(startDevServer).not.toHaveBeenCalled();
+      defineRoutes();
+      expect(startDevServer).toHaveBeenCalled();
+    });
+  }
+});

--- a/src/serve/dev-server-eager-start.test.ts
+++ b/src/serve/dev-server-eager-start.test.ts
@@ -31,6 +31,7 @@ const astro = await import("../../platforms/astro");
 const tanstack = await import("../../platforms/tanstack");
 const nextjs = await import("../../platforms/nextjs");
 const reactRouter = await import("../../platforms/react-router");
+const baseServe = await import("./index");
 
 const routeFunction = async () => {};
 
@@ -49,6 +50,7 @@ const factories: { name: string; defineRoute: () => unknown }[] = [
   { name: "nextjs.serve", defineRoute: () => nextjs.serve(routeFunction) },
   { name: "nextjs.servePagesRouter", defineRoute: () => nextjs.servePagesRouter(routeFunction) },
   { name: "reactRouter.serve", defineRoute: () => reactRouter.serve(routeFunction) },
+  { name: "serve (framework-agnostic root)", defineRoute: () => baseServe.serve(routeFunction) },
 ];
 
 // serveMany factories. For most adapters serveMethod is the adapter `serve`, so

--- a/src/serve/index.ts
+++ b/src/serve/index.ts
@@ -1,3 +1,4 @@
+import { startDevServer } from "@upstash/qstash";
 import { makeCancelRequest } from "../client/utils";
 import {
   SDK_TELEMETRY,
@@ -375,6 +376,7 @@ export const serve = <
   routeFunction: RouteFunction<TInitialPayload, TResult>,
   options?: WorkflowServeOptions<TInitialPayload, TResult>
 ): ReturnType<typeof serveBase<TInitialPayload, TRequest, TResponse, TResult>> => {
+  void startDevServer();
   return serveBase(
     routeFunction,
     {

--- a/src/serve/multi-region/dev-server-integration.test.ts
+++ b/src/serve/multi-region/dev-server-integration.test.ts
@@ -44,8 +44,6 @@ describe("workflow dev server integration", () => {
       },
       { url: workflowUrl }
     ).handler;
-
-    client = new Client({ devMode: true });
   });
 
   afterAll(() => {
@@ -59,10 +57,37 @@ describe("workflow dev server integration", () => {
     while (Date.now() < deadline && !predicate()) await Bun.sleep(100);
   };
 
+  const isDevServerReachable = async () => {
+    try {
+      // Any HTTP response (even an error status) means the dev server is up.
+      await fetch(`http://127.0.0.1:${INTEGRATION_PORT}`);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const waitForAsync = async (predicate: () => Promise<boolean>, timeoutMs = 60_000) => {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline && !(await predicate())) await Bun.sleep(100);
+  };
+
+  test(
+    "dev server is reachable after serve() and before any inbound request",
+    async () => {
+      // The only thing that has run is serve() in beforeAll — no workflow request
+      // has been published yet. This is the new eager-start guarantee.
+      await waitForAsync(isDevServerReachable);
+      expect(await isDevServerReachable()).toBe(true);
+    },
+    { timeout: 60_000 }
+  );
+
   test(
     "multi-step workflow: every dev-server delivery verifies and steps run in order",
     async () => {
       ranSteps.length = 0;
+      client = new Client({ devMode: true });
       const { messageId } = await client.publishJSON({ url: workflowUrl, body: "world" });
       expect(messageId).toBeTruthy();
 

--- a/src/serve/multi-region/handlers.ts
+++ b/src/serve/multi-region/handlers.ts
@@ -58,7 +58,7 @@ const createRegionalHandler = (
   environment: Record<string, string | undefined>,
   receiverConfig: WorkflowReceiver | "set-to-undefined" | "not-set",
   region?: QStashRegion,
-  clientOptions?: Omit<ConstructorParameters<typeof Client>[0], "baseUrl" | "token">
+  clientOptions?: QStashClientExtraConfig
 ): RegionalHandler => {
   const clientEnv = readClientEnvironmentVariables(environment, region);
 
@@ -70,7 +70,8 @@ const createRegionalHandler = (
     // the client at the local dev server too. Without this the QStash Client
     // re-derives dev mode from its own process.env, which is blind to the
     // Cloudflare worker `env` binding that actually carries QSTASH_DEV there.
-    devMode: isQStashDevModeEnabled(environment),
+    // An explicit devMode in the user's client config still wins.
+    devMode: clientOptions?.devMode ?? isQStashDevModeEnabled(environment),
   });
   const receiver = getReceiver(environment, receiverConfig, region);
 
@@ -157,7 +158,7 @@ const getQStashHandlers = ({
                 baseUrl: environment.QSTASH_URL!,
                 token: environment.QSTASH_TOKEN!,
                 // Mirror the receiver's dev-mode decision (see createRegionalHandler).
-                devMode: isQStashDevModeEnabled(environment),
+                devMode: qstashClientOption?.devMode ?? isQStashDevModeEnabled(environment),
               }),
         receiver: getReceiver(environment, receiverConfig),
       },

--- a/src/serve/multi-region/handlers.ts
+++ b/src/serve/multi-region/handlers.ts
@@ -66,6 +66,11 @@ const createRegionalHandler = (
     ...clientOptions,
     baseUrl: clientEnv.QSTASH_URL!,
     token: clientEnv.QSTASH_TOKEN!,
+    // Mirror the receiver's dev-mode decision so a single QSTASH_DEV=true points
+    // the client at the local dev server too. Without this the QStash Client
+    // re-derives dev mode from its own process.env, which is blind to the
+    // Cloudflare worker `env` binding that actually carries QSTASH_DEV there.
+    devMode: isQStashDevModeEnabled(environment),
   });
   const receiver = getReceiver(environment, receiverConfig, region);
 
@@ -151,6 +156,8 @@ const getQStashHandlers = ({
                 ...qstashClientOption,
                 baseUrl: environment.QSTASH_URL!,
                 token: environment.QSTASH_TOKEN!,
+                // Mirror the receiver's dev-mode decision (see createRegionalHandler).
+                devMode: isQStashDevModeEnabled(environment),
               }),
         receiver: getReceiver(environment, receiverConfig),
       },

--- a/src/serve/multi-region/multi-region.test.ts
+++ b/src/serve/multi-region/multi-region.test.ts
@@ -597,4 +597,49 @@ describe("QStash Handler Options - Multi-Region Mode Detection", () => {
       expect(result.defaultClient.http).toBeDefined();
     });
   });
+
+  describe("Client Dev Mode (derived from environment)", () => {
+    // Pins the fix for the receiver-dev / client-prod split: a single
+    // QSTASH_DEV=true (e.g. a Cloudflare `.dev.vars` binding, where the QStash
+    // Client's own process.env lookup is blind) must put the *client* in dev
+    // mode too, matching the receiver. Asserted on the constructed serve Client.
+    const getServeClientHttp = (environment: Record<string, string | undefined>) => {
+      // Entering dev mode makes the Client fire a fire-and-forget dev-server
+      // spawn. NODE_ENV=production short-circuits the spawn while leaving
+      // credential resolution in dev mode, keeping this a pure unit test.
+      const processEnv = process.env as Record<string, string | undefined>;
+      const previousNodeEnv = processEnv.NODE_ENV;
+      processEnv.NODE_ENV = "production";
+      try {
+        const result = getQStashHandlerOptions({ environment, receiverConfig: "not-set" });
+        return result.defaultClient.http as unknown as { baseUrl: string; devMode?: boolean };
+      } finally {
+        if (previousNodeEnv === undefined) delete processEnv.NODE_ENV;
+        else processEnv.NODE_ENV = previousNodeEnv;
+      }
+    };
+
+    test("should put the serve client in dev mode when QSTASH_DEV=true", () => {
+      const http = getServeClientHttp(createEnvironment({ QSTASH_DEV: "true" }));
+      expect(http.devMode).toBe(true);
+      expect(http.baseUrl).toContain("127.0.0.1");
+    });
+
+    test("should put the serve client in dev mode when QSTASH_DEV=1", () => {
+      const http = getServeClientHttp(createEnvironment({ QSTASH_DEV: "1" }));
+      expect(http.devMode).toBe(true);
+      expect(http.baseUrl).toContain("127.0.0.1");
+    });
+
+    test("should keep the serve client pointed at production without QSTASH_DEV", () => {
+      const http = getServeClientHttp(
+        createEnvironment({
+          QSTASH_URL: "https://qstash.upstash.io",
+          QSTASH_TOKEN: "test-token",
+        })
+      );
+      expect(http.devMode).toBe(false);
+      expect(http.baseUrl).toBe("https://qstash.upstash.io");
+    });
+  });
 });

--- a/src/serve/multi-region/multi-region.test.ts
+++ b/src/serve/multi-region/multi-region.test.ts
@@ -603,7 +603,10 @@ describe("QStash Handler Options - Multi-Region Mode Detection", () => {
     // QSTASH_DEV=true (e.g. a Cloudflare `.dev.vars` binding, where the QStash
     // Client's own process.env lookup is blind) must put the *client* in dev
     // mode too, matching the receiver. Asserted on the constructed serve Client.
-    const getServeClientHttp = (environment: Record<string, string | undefined>) => {
+    const getServeClientHttp = (
+      environment: Record<string, string | undefined>,
+      qstashClientOption?: { devMode?: boolean }
+    ) => {
       // Entering dev mode makes the Client fire a fire-and-forget dev-server
       // spawn. NODE_ENV=production short-circuits the spawn while leaving
       // credential resolution in dev mode, keeping this a pure unit test.
@@ -611,7 +614,11 @@ describe("QStash Handler Options - Multi-Region Mode Detection", () => {
       const previousNodeEnv = processEnv.NODE_ENV;
       processEnv.NODE_ENV = "production";
       try {
-        const result = getQStashHandlerOptions({ environment, receiverConfig: "not-set" });
+        const result = getQStashHandlerOptions({
+          environment,
+          qstashClientOption,
+          receiverConfig: "not-set",
+        });
         return result.defaultClient.http as unknown as { baseUrl: string; devMode?: boolean };
       } finally {
         if (previousNodeEnv === undefined) delete processEnv.NODE_ENV;
@@ -637,6 +644,33 @@ describe("QStash Handler Options - Multi-Region Mode Detection", () => {
           QSTASH_URL: "https://qstash.upstash.io",
           QSTASH_TOKEN: "test-token",
         })
+      );
+      expect(http.devMode).toBe(false);
+      expect(http.baseUrl).toBe("https://qstash.upstash.io");
+    });
+
+    // devMode in the user's qstashClient config takes precedence over the
+    // env-derived value, in both directions — the env check is only a fallback.
+    test("explicit qstashClient devMode: true wins without QSTASH_DEV", () => {
+      const http = getServeClientHttp(
+        createEnvironment({
+          QSTASH_URL: "https://qstash.upstash.io",
+          QSTASH_TOKEN: "test-token",
+        }),
+        { devMode: true }
+      );
+      expect(http.devMode).toBe(true);
+      expect(http.baseUrl).toContain("127.0.0.1");
+    });
+
+    test("explicit qstashClient devMode: false wins over QSTASH_DEV=true", () => {
+      const http = getServeClientHttp(
+        createEnvironment({
+          QSTASH_DEV: "true",
+          QSTASH_URL: "https://qstash.upstash.io",
+          QSTASH_TOKEN: "test-token",
+        }),
+        { devMode: false }
       );
       expect(http.devMode).toBe(false);
       expect(http.baseUrl).toBe("https://qstash.upstash.io");

--- a/src/serve/multi-region/multi-region.test.ts
+++ b/src/serve/multi-region/multi-region.test.ts
@@ -3,7 +3,7 @@
  * Tests credential resolution and region handling.
  */
 
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { Client, Receiver } from "@upstash/qstash";
 import {
   getRegionFromEnvironment,
@@ -12,6 +12,25 @@ import {
   readReceiverEnvironmentVariables,
 } from "./utils";
 import { getQStashHandlerOptions } from "./handlers";
+
+// Constructing handler options with QSTASH_DEV=true makes the QStash Client
+// fire a fire-and-forget dev-server spawn, which also latches a process-wide
+// singleton inside @upstash/qstash — a later startDevServer() in the same bun
+// process (dev-server-integration.test.ts) then no-ops on its own port.
+// NODE_ENV=production short-circuits the spawn while leaving dev-mode
+// credential resolution intact, keeping this file a pure unit test.
+const processEnvironment = process.env as Record<string, string | undefined>;
+let previousNodeEnvironment: string | undefined;
+
+beforeAll(() => {
+  previousNodeEnvironment = processEnvironment.NODE_ENV;
+  processEnvironment.NODE_ENV = "production";
+});
+
+afterAll(() => {
+  if (previousNodeEnvironment === undefined) delete processEnvironment.NODE_ENV;
+  else processEnvironment.NODE_ENV = previousNodeEnvironment;
+});
 
 // Helper to create a clean environment for each test
 const createEnvironment = (


### PR DESCRIPTION
## Summary

Eager-starts the QStash dev server whenever `serve()` is called, so local dev "just works" without manually running the dev binary.

- Call `void startDevServer()` in all 10 platform adapters (astro, cloudflare, express, h3, hono, nextjs, react-router, solidjs, svelte, tanstack), plus `nextjs` `servePagesRouter` and `express` `serveMany`.
- Derive `devMode` onto the serve-side `Client` in `src/serve/multi-region/handlers.ts` so the multi-region path respects dev mode.
- Tests: new `src/serve/dev-server-eager-start.test.ts`; updates to `multi-region.test.ts` and `dev-server-integration.test.ts` (the integration test spawns the real dev binary).

## Dependency

Pins `@upstash/qstash` to CI snapshot `0.0.0-ci.8c658c13532090cf00f778d2216eacbad68f85f9-20260618065901` (which exports `startDevServer`) for integration testing.

Depends on / pins the qstash-js CI snapshot from upstash/qstash-js#269. To be repinned to a stable `@upstash/qstash` release before merge.

## Local verification

- `tsc --noEmit` clean
- `eslint` clean
- `bun run build` succeeds
- changed/new tests: 62 pass, 0 fail
