### PR TITLE
feat(types): add nextDeliveryTime to FailureFunctionLog

### DIFF
--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -264,6 +264,7 @@ type FailureFunctionLog = {
    * Status code of the response from the failure function
    */
   responseStatus?: number;
+  nextDeliveryTime?: number;
 };
 
 export type WorkflowRunLog = {


### PR DESCRIPTION
The `FailureFunctionLog` type was missing `nextDeliveryTime`, which the QStash backend returns on the failure callback while `state === "CALLBACK_INPROGRESS"` (unix-ms timestamp of the next retry attempt). Verified against prod QStash.