### PR TITLE
DX-2636: add CALLBACK_CANCELED to failure callback state unions

### DIFF
--- a/src/client/dlq.ts
+++ b/src/client/dlq.ts
@@ -15,7 +15,7 @@ type ResumeRestartOptions = {
 };
 
 type FailureCallbackInfo = {
-  state?: "CALLBACK_FAIL" | "CALLBACK_SUCCESS" | "CALLBACK_INPROGRESS";
+  state?: "CALLBACK_FAIL" | "CALLBACK_SUCCESS" | "CALLBACK_INPROGRESS" | "CALLBACK_CANCELED";
   responseStatus?: number;
   responseBody?: string;
   responseHeaders?: Record<string, string[]>;

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -231,7 +231,7 @@ type FailureFunctionLog = {
   /**
    * State of the message published for failure
    */
-  state: "CALLBACK_INPROGRESS" | "CALLBACK_SUCCESS" | "CALLBACK_FAIL";
+  state: "CALLBACK_INPROGRESS" | "CALLBACK_SUCCESS" | "CALLBACK_FAIL" | "CALLBACK_CANCELED";
   /**
    * Headers received from the step which caused the workflow to fail
    */


### PR DESCRIPTION
## Summary

`FailureCallbackState` in qstash-server (`pkg/proto/message.proto:277`) has four values — `CALLBACK_INPROGRESS`, `CALLBACK_SUCCESS`, `CALLBACK_FAIL`, `CALLBACK_CANCELED` — but the SDK's mirrored unions only listed three, so a canceled failure callback did not typecheck against the value the server actually sends.

`CALLBACK_CANCELED` is genuinely emitted on both surfaces:
- `WorkflowRun.failureFunction.state` comes from `MessageStateToCallbackState` (`pkg/types/workflow.go:610`), which maps the `CANCELED` / `CANCEL_REQUESTED` event states to `CALLBACK_CANCELED`.
- `DLQMessage.failureCallbackInfo.state` is the proto enum serialized by name (`pkg/api/public/message_get.go:133`), and `pkg/api/public/workflow_dlq.go:289` writes `CALLBACK_CANCELED` into it when a failure callback is canceled.

## Changes

- `src/client/types.ts` — add `CALLBACK_CANCELED` to `FailureFunctionLog.state`.
- `src/client/dlq.ts` — add `CALLBACK_CANCELED` to `FailureCallbackInfo.state`.

## Testing

Type-only change. `tsc --noEmit`, eslint, and prettier all pass.