### PR TITLE
fix: don't run CI on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ permissions:
 
 jobs:
   tests:
-    if: github.event_name != 'release'
+    if: github.repository_owner == 'upstash' && github.event_name != 'release'
     uses: ./.github/workflows/test.yaml
     secrets: inherit
 
   release:
-    if: github.event_name == 'release'
+    if: github.repository_owner == 'upstash' && github.event_name == 'release'
     uses: ./.github/workflows/release.yaml
     with:
       prerelease: ${{ github.event.release.prerelease }}


### PR DESCRIPTION
The nightly schedule trigger also fires on forks' default branches, where the QStash and Redis secrets are unavailable, producing a failed run every day. Gate both jobs on the repository owner so they skip on forks.

PRs from forks into upstash/workflow-js are unaffected, since those run in the upstream repository's context.

Fixes #189