### PR TITLE
test: accept zod v4 error message in schema validation test

### DIFF
--- a/src/workflow-parser.test.ts
+++ b/src/workflow-parser.test.ts
@@ -937,7 +937,8 @@ describe("schema validation in serve", () => {
     if (expectedError) {
       const { error, message } = (await response.json()) as { error: string; message: string };
       expect(error).toBe("ZodError");
-      expect(message).toContain(expectedError);
+      // zod v3: "Expected string, received number"; zod v4: "Invalid input: expected string, received number"
+      expect(message.toLowerCase()).toContain(expectedError.toLowerCase());
     } else {
       const { message, workflowRunId } = (await response.json()) as {
         message: string;
@@ -957,7 +958,7 @@ describe("schema validation in serve", () => {
   test("schema - valid payload", () => testServe({ schema }, validPayload, 400));
 
   test("schema - invalid payload", () =>
-    testServe({ schema }, invalidPayload, 500, "Expected string, received number"));
+    testServe({ schema }, invalidPayload, 500, "expected string, received number"));
 
   test("parser - valid payload", () =>
     testServe({ initialPayloadParser: parser }, validPayload, 400));


### PR DESCRIPTION
DX-2954. bun 1.4 resolves the zod peer dependency (^3.25.0 || ^4.0.0) to 4.x in CI, whose invalid_type message is 'Invalid input: expected string, received number' instead of zod 3's 'Expected string, received number'. Compare case-insensitively so the test passes under both majors.